### PR TITLE
fix: update completions scripts — remove .sh refs, add add-provider

### DIFF
--- a/tools/setup-cli/Templates/tools/completions.ps1
+++ b/tools/setup-cli/Templates/tools/completions.ps1
@@ -12,9 +12,10 @@ Register-ArgumentCompleter -Native -CommandName multiagent-setup -ScriptBlock {
     if ($tokens.Count -eq 0 -or ($tokens.Count -eq 1 -and -not $sub.StartsWith('-') -and $wordToComplete)) {
         @(
             [pscustomobject]@{ name = 'new';          desc = 'Create a new multi-agent workspace' }
-            [pscustomobject]@{ name = 'sync-roles';   desc = 'Sync agent roles to ~/.claude/commands/' }
+            [pscustomobject]@{ name = 'add-provider'; desc = 'Add a provider to an existing workspace' }
+            [pscustomobject]@{ name = 'sync-roles';   desc = 'Sync agent roles to .claude/commands/ (project-local)' }
             [pscustomobject]@{ name = 'install-mcps'; desc = 'Install age-mcp and o-brien MCP servers' }
-            [pscustomobject]@{ name = 'hook';         desc = 'Run a Claude Code hook (cross-platform)' }
+            [pscustomobject]@{ name = 'hook';         desc = 'Run a built-in hook (cross-platform)' }
         ) | Where-Object { $_.name -like "$wordToComplete*" } | ForEach-Object {
             [System.Management.Automation.CompletionResult]::new($_.name, $_.name, 'ParameterValue', $_.desc)
         }
@@ -23,8 +24,30 @@ Register-ArgumentCompleter -Native -CommandName multiagent-setup -ScriptBlock {
 
     # Complete flags per subcommand
     switch ($sub) {
+        'new' {
+            if ($tokens.Count -le 2) {
+                @('--provider') | Where-Object { $_ -like "$wordToComplete*" } | ForEach-Object {
+                    [System.Management.Automation.CompletionResult]::new($_, $_, 'ParameterName', $_)
+                }
+            } elseif ($tokens[-2] -eq '--provider') {
+                @('claude', 'nessy', 'gemini', 'codex', 'qwen', 'all') | Where-Object { $_ -like "$wordToComplete*" } | ForEach-Object {
+                    [System.Management.Automation.CompletionResult]::new($_, $_, 'ParameterValue', $_)
+                }
+            }
+        }
+        'add-provider' {
+            if ($tokens.Count -eq 1 -or ($tokens.Count -eq 2 -and $wordToComplete)) {
+                @('claude', 'nessy', 'gemini', 'codex', 'qwen', 'all') | Where-Object { $_ -like "$wordToComplete*" } | ForEach-Object {
+                    [System.Management.Automation.CompletionResult]::new($_, $_, 'ParameterValue', $_)
+                }
+            } else {
+                @('--force') | Where-Object { $_ -like "$wordToComplete*" } | ForEach-Object {
+                    [System.Management.Automation.CompletionResult]::new($_, $_, 'ParameterName', $_)
+                }
+            }
+        }
         'sync-roles' {
-            @('--clone', '--pull', '--agency-dir') | Where-Object { $_ -like "$wordToComplete*" } | ForEach-Object {
+            @('--clone', '--pull', '--agency-dir', '--workspace-root') | Where-Object { $_ -like "$wordToComplete*" } | ForEach-Object {
                 [System.Management.Automation.CompletionResult]::new($_, $_, 'ParameterName', $_)
             }
         }

--- a/tools/setup-cli/Templates/tools/completions.zsh
+++ b/tools/setup-cli/Templates/tools/completions.zsh
@@ -1,33 +1,54 @@
-# Multi-Agent Workspace — zsh completions
+# Multi-Agent Workspace — zsh completions for multiagent-setup
 # Source this file: source ./tools/completions.zsh
 # Or add to ~/.zshrc: source /path/to/project/tools/completions.zsh
 
-# --- sync-roles.sh ---
-_sync_roles() {
-  local -a opts
-  opts=(
-    '--clone:Clone agency-agents repo if missing, then sync'
-    '--pull:Git pull latest roles before sync'
+# --- multiagent-setup ---
+_multiagent_setup() {
+  local -a subcommands
+  subcommands=(
+    'new:Create a new multi-agent workspace'
+    'add-provider:Add a provider to an existing workspace'
+    'sync-roles:Sync agent roles to .claude/commands/'
+    'install-mcps:Install age-mcp and o-brien MCP servers'
+    'hook:Run a built-in hook (cross-platform)'
   )
-  _describe 'option' opts
-}
-compdef _sync_roles sync-roles.sh
-compdef _sync_roles ./tools/sync-roles.sh
-compdef _sync_roles tools/sync-roles.sh
 
-# --- setup.sh ---
-_setup_sh() {
+  local -a providers
+  providers=(claude nessy gemini codex qwen all)
+
+  local -a hooks
+  hooks=(block-dangerous enforce-commit-msg auto-lint log-agent stop-guard research-reminder)
+
   case $CURRENT in
-    2) _message 'project-name' ;;
-    3) _message 'github-org (default: project-name)' ;;
+    2)
+      _describe 'subcommand' subcommands
+      ;;
+    *)
+      case ${words[2]} in
+        new|add-provider)
+          case $CURRENT in
+            3) _message 'project-name or provider' ;;
+            *) compadd -- --provider ${providers[@]} --force ;;
+          esac
+          ;;
+        sync-roles)
+          compadd -- --clone --pull --agency-dir --workspace-root
+          ;;
+        install-mcps)
+          compadd -- --docker --manual --age-conn --obrien-conn --target
+          ;;
+        hook)
+          compadd -- ${hooks[@]}
+          ;;
+      esac
+      ;;
   esac
 }
-compdef _setup_sh setup.sh
-compdef _setup_sh ./setup.sh
+compdef _multiagent_setup multiagent-setup
 
-# --- /slash-commands via claude ---
+# --- /slash-commands via claude / nessy / gemini ---
 # Completes role names from ~/.claude/commands/ and .claude/commands/
-_claude_slash() {
+_ai_slash_commands() {
   local -a roles
   local dir
 
@@ -47,15 +68,16 @@ _claude_slash() {
 
   # Deduplicate
   roles=(${(u)roles})
-
   _describe 'slash-command' roles
 }
 
-# Bind to claude CLI if available
-if (( $+commands[claude] )); then
-  # Complete slash commands when typing / after claude
-  compdef _claude_slash claude
-fi
+# Bind slash-command completion to supported agent CLIs
+for _agent_cmd in claude nessy gemini; do
+  if (( $+commands[$_agent_cmd] )); then
+    compdef _ai_slash_commands $_agent_cmd
+  fi
+done
+unset _agent_cmd
 
 # --- orchestrator pipeline types ---
 _orchestrator_pipelines() {


### PR DESCRIPTION
The completions scripts still referenced old .sh wrapper scripts and were missing the new subcommands. This PR:
- Rewrites completions.zsh: proper multiagent-setup subcommand tree, add-provider with provider tab-completion, binds slash-command completion to claude/nessy/gemini
- Rewrites completions.ps1: adds add-provider with provider value completion, --force flag, --workspace-root for sync-roles, updates sync-roles description