### PR TITLE
feat: add-provider subcommand

### DIFF
--- a/tools/setup-cli/AddProviderCommand.cs
+++ b/tools/setup-cli/AddProviderCommand.cs
@@ -1,0 +1,101 @@
+using System.Runtime.InteropServices;
+
+namespace MultiagentSetup;
+
+public sealed class AddProviderCommand(string provider, string? workspaceDir = null, bool force = false)
+{
+    private static readonly string[] AllProviders = ["claude", "nessy", "gemini", "codex", "qwen"];
+
+    public async Task<int> ExecuteAsync()
+    {
+        var wsRoot = Path.GetFullPath(workspaceDir ?? Directory.GetCurrentDirectory());
+
+        if (!Directory.Exists(wsRoot))
+        {
+            Console.Error.WriteLine($"Error: directory not found: {wsRoot}");
+            return 1;
+        }
+
+        if (!IsWorkspace(wsRoot))
+            Console.WriteLine("  WARN: directory doesn't look like a multiagent workspace (no CLAUDE.md or .claude/)");
+
+        var providers = provider == "all" ? AllProviders : new[] { provider };
+        var installed = DetectInstalled(wsRoot);
+        var toAdd     = force ? providers : providers.Where(p => !installed.Contains(p)).ToArray();
+        var skipped   = providers.Except(toAdd).ToArray();
+
+        if (skipped.Length > 0)
+            Console.WriteLine($"  Already configured: {string.Join(", ", skipped)}" +
+                              (force ? "" : " — use --force to overwrite"));
+
+        if (toAdd.Length == 0)
+        {
+            Console.WriteLine("Nothing to add.");
+            return 0;
+        }
+
+        Console.WriteLine($"Adding: {string.Join(", ", toAdd)}");
+        Console.WriteLine();
+
+        // Infer project name from workspace folder name
+        var projectName = Path.GetFileName(wsRoot);
+        var graphName   = $"{projectName.ToLower()}-ops";
+
+        // Resolve org (best-effort — used only in template substitution)
+        var (_, orgOut, _) = await ProcessHelper.RunAsync("gh", ["api", "user", "--jq", ".login"],
+            captureOutput: true, allowFailure: true);
+        var org = string.IsNullOrWhiteSpace(orgOut) ? projectName : orgOut.Trim();
+
+        SetupCommand.CreateDirectories(wsRoot, toAdd);
+
+        var vars = SetupCommand.BuildVars(projectName, org, graphName);
+        SetupCommand.ExtractTemplates(wsRoot, vars, toAdd, skipExisting: !force);
+        Console.WriteLine("  OK: templates extracted");
+
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            await SetupCommand.ChmodShellScriptsAsync(wsRoot);
+            Console.WriteLine("  OK: permissions set");
+        }
+
+        if (toAdd.Any(p => p is "claude" or "nessy"))
+            await SetupCommand.SetupAgencyRolesAsync(wsRoot);
+
+        Console.WriteLine();
+        Console.WriteLine($"Done! Added {string.Join(", ", toAdd)} to {wsRoot}");
+        Console.WriteLine();
+
+        foreach (var p in toAdd)
+        {
+            var cmd = p switch
+            {
+                "claude" or "nessy" => p,
+                "gemini"            => "gemini",
+                "codex"             => "codex",
+                "qwen"              => "qwen-code",
+                _                   => p
+            };
+            Console.WriteLine($"  Start {p}: {cmd}  →  /orchestrator <task>");
+        }
+        Console.WriteLine();
+        return 0;
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private static bool IsWorkspace(string root) =>
+        File.Exists(Path.Combine(root, "CLAUDE.md"))  ||
+        Directory.Exists(Path.Combine(root, ".claude")) ||
+        File.Exists(Path.Combine(root, "GEMINI.md"))  ||
+        Directory.Exists(Path.Combine(root, ".gemini"));
+
+    private static HashSet<string> DetectInstalled(string root)
+    {
+        var result = new HashSet<string>();
+        if (Directory.Exists(Path.Combine(root, ".claude"))) { result.Add("claude"); result.Add("nessy"); }
+        if (Directory.Exists(Path.Combine(root, ".gemini"))) result.Add("gemini");
+        if (Directory.Exists(Path.Combine(root, ".codex")))  result.Add("codex");
+        if (Directory.Exists(Path.Combine(root, ".qwen")))   result.Add("qwen");
+        return result;
+    }
+}

--- a/tools/setup-cli/Program.cs
+++ b/tools/setup-cli/Program.cs
@@ -13,6 +13,7 @@ if (args[0] is "-v" or "--version")
 return args[0] switch
 {
     "new"           => await HandleNew(args[1..]),
+    "add-provider"  => await HandleAddProvider(args[1..]),
     "sync-roles"    => await HandleSyncRoles(args[1..]),
     "install-mcps"  => await new InstallMcpsCommand(args[1..]).ExecuteAsync(),
     "hook"          => await HandleHook(args[1..]),
@@ -43,6 +44,26 @@ async Task<int> HandleNew(string[] a)
     return await new SetupCommand(name, org, provider).ExecuteAsync();
 }
 
+async Task<int> HandleAddProvider(string[] a)
+{
+    var provider = a.FirstOrDefault(x => !x.StartsWith('-')) ?? "";
+    if (string.IsNullOrEmpty(provider))
+        return PrintUsage(error: "add-provider requires a provider name: claude, nessy, gemini, codex, qwen, all");
+
+    string[] validProviders = ["claude", "codex", "qwen", "nessy", "gemini", "all"];
+    if (!validProviders.Contains(provider))
+        return PrintUsage(error: $"Unknown provider '{provider}'. Valid: claude, codex, qwen, nessy, gemini, all");
+
+    string? wsDir = null;
+    bool force = false;
+    for (int i = 0; i < a.Length; i++)
+    {
+        if (a[i] == "--workspace-dir" && i + 1 < a.Length) wsDir = a[++i];
+        if (a[i] == "--force") force = true;
+    }
+    return await new AddProviderCommand(provider, wsDir, force).ExecuteAsync();
+}
+
 async Task<int> HandleHook(string[] a)
 {
     var name = a.ElementAtOrDefault(0);
@@ -71,6 +92,9 @@ static int PrintUsage(string? error = null)
     Console.WriteLine("Commands:");
     Console.WriteLine("  new <project-name> [github-org]    Create a new multi-agent workspace");
     Console.WriteLine("    --provider <name>                 Provider: claude (default), codex, qwen, nessy, gemini, all");
+    Console.WriteLine("  add-provider <provider>            Add a provider to an existing workspace");
+    Console.WriteLine("    --workspace-dir <path>            Workspace root (default: cwd)");
+    Console.WriteLine("    --force                           Overwrite existing provider config");
     Console.WriteLine("  sync-roles [--clone|--pull]         Sync agent roles to .claude/commands/ (project-local)");
     Console.WriteLine("    --agency-dir <path>               Override agency-agents directory");
     Console.WriteLine("    --workspace-root <path>           Target project root (default: cwd)");

--- a/tools/setup-cli/SetupCommand.cs
+++ b/tools/setup-cli/SetupCommand.cs
@@ -153,7 +153,7 @@ public sealed class SetupCommand(string projectName, string? requestedOrg, strin
 
     // ── Directory creation ────────────────────────────────────────────────────
 
-    private static void CreateDirectories(string root, string[] providers)
+    internal static void CreateDirectories(string root, string[] providers)
     {
         // Shared
         foreach (var d in new[] { "code", "docs/workflows", "docs/archive", "docs/obsolete-docs", "tools" })
@@ -184,7 +184,7 @@ public sealed class SetupCommand(string projectName, string? requestedOrg, strin
 
     // ── Template extraction ───────────────────────────────────────────────────
 
-    private static Dictionary<string, string> BuildVars(string project, string org, string graph) => new()
+    internal static Dictionary<string, string> BuildVars(string project, string org, string graph) => new()
     {
         ["{{PROJECT_NAME}}"]        = project,
         ["{{PROJECT_DESCRIPTION}}"] = $"{project} project workspace",
@@ -199,7 +199,7 @@ public sealed class SetupCommand(string projectName, string? requestedOrg, strin
                                         : "$HOME/.dotnet/tools/multiagent-setup",
     };
 
-    private static void ExtractTemplates(string root, Dictionary<string, string> vars, string[] providers)
+    internal static void ExtractTemplates(string root, Dictionary<string, string> vars, string[] providers, bool skipExisting = false)
     {
         var asm = Assembly.GetExecutingAssembly();
         foreach (var resourceName in asm.GetManifestResourceNames())
@@ -208,6 +208,7 @@ public sealed class SetupCommand(string projectName, string? requestedOrg, strin
             if (outputRel is null) continue;
 
             var outputPath = Path.Combine(root, outputRel.Replace('/', Path.DirectorySeparatorChar));
+            if (skipExisting && File.Exists(outputPath)) continue;
             Directory.CreateDirectory(Path.GetDirectoryName(outputPath)!);
 
             using var stream = asm.GetManifestResourceStream(resourceName)!;
@@ -228,7 +229,7 @@ public sealed class SetupCommand(string projectName, string? requestedOrg, strin
         }
     }
 
-    private static string? ResolveOutputPath(string resourceName, string[] providers)
+    internal static string? ResolveOutputPath(string resourceName, string[] providers)
     {
         if (resourceName.StartsWith(".claude/"))
             return (providers.Contains("claude") || providers.Contains("nessy")) ? resourceName : null; // nessy intentionally reuses claude templates
@@ -249,7 +250,7 @@ public sealed class SetupCommand(string projectName, string? requestedOrg, strin
         return resourceName;
     }
 
-    private static bool IsTextResource(string name) =>
+    internal static bool IsTextResource(string name) =>
         name.EndsWith(".md")   ||
         name.EndsWith(".json") ||
         name.EndsWith(".toml") ||
@@ -259,7 +260,7 @@ public sealed class SetupCommand(string projectName, string? requestedOrg, strin
 
     // ── Permissions ───────────────────────────────────────────────────────────
 
-    private static async Task ChmodShellScriptsAsync(string root)
+    internal static async Task ChmodShellScriptsAsync(string root)
     {
         var scripts = Directory.GetFiles(root, "*.csx", SearchOption.AllDirectories)
             .Concat(Directory.GetFiles(root, "*.zsh", SearchOption.AllDirectories));
@@ -269,7 +270,7 @@ public sealed class SetupCommand(string projectName, string? requestedOrg, strin
 
     // ── Agency-agents + role sync ─────────────────────────────────────────────
 
-    private static async Task SetupAgencyRolesAsync(string workspaceRoot)
+    internal static async Task SetupAgencyRolesAsync(string workspaceRoot)
     {
         var agencyDir = Path.GetFullPath(Path.Combine(workspaceRoot, "..", "agency-agents"));
         await new SyncRolesCommand("--clone", agencyDir, workspaceRoot).ExecuteAsync();


### PR DESCRIPTION
## Summary
- New `multiagent-setup add-provider <provider>` command adds a provider (claude/nessy/gemini/codex/qwen/all) to an **existing** workspace without recreating it
- Detects already-installed providers by checking for `.claude/`, `.gemini/`, `.codex/`, `.qwen/` directories — skips them by default
- `--force` flag overwrites existing provider config
- `--workspace-dir <path>` targets a workspace other than cwd
- `SetupCommand` methods made `internal static` so `AddProviderCommand` can reuse them
- `ExtractTemplates` gains `skipExisting` parameter to preserve user-modified files

## Closes
Closes #5

## Test plan
- [ ] `multiagent-setup add-provider gemini` in an existing claude workspace → adds `.gemini/` without touching `.claude/`
- [ ] `multiagent-setup add-provider all` → adds only missing providers
- [ ] `multiagent-setup add-provider gemini --force` → overwrites `.gemini/settings.json`
- [ ] `multiagent-setup add-provider` (no arg) → prints usage error
- [ ] `multiagent-setup add-provider badname` → prints usage error
- [ ] `dotnet build` passes with 0 warnings