### PR TITLE
ci: add cross-platform build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,27 @@
+name: Build
+
+on:
+  push:
+    branches: [ main, 'feat/**', 'fix/**', 'chore/**', 'docs/**' ]
+  pull_request:
+    branches: [ main, 'feat/**' ]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ ubuntu-latest, windows-latest, macos-latest ]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.x'
+
+      - name: Build
+        run: dotnet build tools/setup-cli/MultiagentSetup.csproj -c Release --nologo
+
+      - name: Pack (verify templates embed)
+        run: dotnet pack tools/setup-cli/MultiagentSetup.csproj -c Release --no-build --nologo -o nupkg


### PR DESCRIPTION
## Summary
- Adds a `build.yml` workflow that builds and packs the .NET tool on every push/PR
- Runs on Ubuntu, Windows, and macOS to catch cross-platform issues early
- Pack step verifies that all templates embed correctly into the binary

Without this, broken PRs could be merged without detecting build failures.