### PR TITLE
fix: security hardening — 5 issues from code review

### DIFF
--- a/tools/setup-cli/HooksCommand.cs
+++ b/tools/setup-cli/HooksCommand.cs
@@ -97,9 +97,14 @@ public sealed class HooksCommand(string hookName)
 
     private static string ExtractCommitMessage(string cmd)
     {
-        var m = Regex.Match(cmd, @"-m\s+""([^""]+)""");
+        // -m "..." or --message "..."
+        var m = Regex.Match(cmd, @"(?:-m|--message)[= ]+""([^""]+)""");
         if (m.Success) return m.Groups[1].Value;
-        m = Regex.Match(cmd, @"-m\s+'([^']+)'");
+        // -m '...' or --message '...'
+        m = Regex.Match(cmd, @"(?:-m|--message)[= ]+'([^']+)'");
+        if (m.Success) return m.Groups[1].Value;
+        // --message=value (no quotes)
+        m = Regex.Match(cmd, @"--message=(\S+)");
         if (m.Success) return m.Groups[1].Value;
         // heredoc with literal \n
         return cmd.Replace("\\n", "\n")

--- a/tools/setup-cli/InstallMcpsCommand.cs
+++ b/tools/setup-cli/InstallMcpsCommand.cs
@@ -79,8 +79,8 @@ public sealed class InstallMcpsCommand
         Console.WriteLine("  my-mcps installed!");
         Console.WriteLine("================================");
         Console.WriteLine();
-        Console.WriteLine($"  age-mcp connection: {ageConn}");
-        Console.WriteLine($"  o-brien connection: {obrienDbUrl}");
+        Console.WriteLine($"  age-mcp connection: {RedactPassword(ageConn)}");
+        Console.WriteLine($"  o-brien connection: {RedactPassword(obrienDbUrl)}");
         Console.WriteLine();
         Console.WriteLine("  Start a Claude Code session — both MCPs are ready.");
         Console.WriteLine();
@@ -124,6 +124,16 @@ public sealed class InstallMcpsCommand
 
         await SetupDockerAsync();
         return (AgeConnDocker, ObrienDbUrlDocker);
+    }
+
+    /// Redact the password from a PostgreSQL connection string for safe display.
+    private static string RedactPassword(string connStr)
+    {
+        // Handles both URI form (postgresql://user:pass@host/db) and key=value form (Password=xxx;...)
+        var uri = System.Text.RegularExpressions.Regex.Replace(
+            connStr, @"(?<=://[^:@]*:)[^@]+(?=@)", "***");
+        return System.Text.RegularExpressions.Regex.Replace(
+            uri, @"(?i)(?<=password\s*=\s*)[^;]+", "***");
     }
 
     private static string Prompt(string label, string defaultValue)
@@ -242,8 +252,10 @@ public sealed class InstallMcpsCommand
             Console.WriteLine("  ..  Starting existing o-brien container...");
             await ProcessHelper.RunAsync("docker", ["start", ObrienContainer],
                 captureOutput: true, allowFailure: false);
-            await WaitForPortAsync(ObrienPort);
-            Console.WriteLine($"  OK: o-brien database running on :{ObrienPort}");
+            var startOk = await WaitForPortAsync(ObrienPort);
+            Console.WriteLine(startOk
+                ? $"  OK: o-brien database running on :{ObrienPort}"
+                : $"  WARN: o-brien postgres not reachable on :{ObrienPort} yet");
         }
         else
         {

--- a/tools/setup-cli/SetupCommand.cs
+++ b/tools/setup-cli/SetupCommand.cs
@@ -21,6 +21,12 @@ public sealed class SetupCommand(string projectName, string? requestedOrg, strin
         var org = await ResolveOrgAsync();
         if (org is null) return 1;
 
+        if (projectName.Contains('/') || projectName.Contains('\\') || projectName.Contains(".."))
+        {
+            Console.Error.WriteLine("Error: project name must not contain path separators or '..'");
+            return 1;
+        }
+
         var targetDir = Path.GetFullPath(Path.Combine(Directory.GetCurrentDirectory(), projectName));
         if (Directory.Exists(targetDir))
         {
@@ -207,7 +213,11 @@ public sealed class SetupCommand(string projectName, string? requestedOrg, strin
             var outputRel = ResolveOutputPath(resourceName, providers);
             if (outputRel is null) continue;
 
-            var outputPath = Path.Combine(root, outputRel.Replace('/', Path.DirectorySeparatorChar));
+            var outputPath = Path.GetFullPath(Path.Combine(root, outputRel.Replace('/', Path.DirectorySeparatorChar)));
+            // Guard against path traversal via crafted resource names
+            if (!outputPath.StartsWith(root + Path.DirectorySeparatorChar, StringComparison.Ordinal) &&
+                outputPath != root)
+                continue;
             Directory.CreateDirectory(Path.GetDirectoryName(outputPath)!);
 
             using var stream = asm.GetManifestResourceStream(resourceName)!;


### PR DESCRIPTION
## Summary

Security fixes from automated code review:

**[Critical] Path traversal via embedded template resource names**
- `ExtractTemplates` now validates that computed output path stays within workspace root before writing any file
- A crafted resource name with `../` sequences could previously write outside the target directory

**[Important] Project name path traversal**
- `new` command now rejects project names containing `/`, `\`, or `..`
- `../../../etc/attack` passed the `Directory.Exists` check before

**[Important] `EnforceCommitMsg` missed `--message` long form**
- `ExtractCommitMessage` now matches `--message "..."`, `--message='...'`, and `--message=value` in addition to `-m`
- Without this fix, `git commit --message="feat: x"` bypassed conventional commit enforcement entirely

**[Important] `WaitForPortAsync` return value discarded**
- `docker start` path now checks the return value and prints `WARN` on failure instead of unconditionally printing `OK`

**[Important] Connection strings printed to stdout**
- Passwords in both URI form (`postgresql://user:pass@host/db`) and key=value form (`Password=xxx;`) are now redacted to `***` before printing

## Test plan
- [ ] `dotnet build` passes (0 warnings)
- [ ] `multiagent-setup new ../attack` → prints error, exits 1
- [ ] `multiagent-setup new valid-name` → works normally
- [ ] `git commit --message="fix: something"` in a workspace → hook validates correctly