### PR TITLE
fix: sync-roles defaults to --pull when called without an action

### DIFF
--- a/tools/setup-cli/SyncRolesCommand.cs
+++ b/tools/setup-cli/SyncRolesCommand.cs
@@ -23,6 +23,9 @@ public sealed class SyncRolesCommand(string action, string? agencyDirOverride, s
 
         var currentAction = action;
 
+        if (currentAction != "--clone" && currentAction != "--pull")
+            currentAction = "--pull"; // default to pull when no action specified
+
         // ── Clone ─────────────────────────────────────────────────────────────
         if (currentAction == "--clone")
         {


### PR DESCRIPTION
## Summary
`multiagent-setup sync-roles` with no `--clone` or `--pull` argument previously fell through silently (neither branch triggered, but the sync step ran anyway against whatever `agencyDir` resolved to). 

Now defaults to `--pull` so `sync-roles` alone does the right thing without requiring an explicit flag.

Fixes architecture issue flagged in security/code review.