### PR TITLE
feat: add Cursor, Windsurf, and GitHub Copilot providers (v1.9.0)

### DIFF
--- a/tools/setup-cli/MultiagentSetup.csproj
+++ b/tools/setup-cli/MultiagentSetup.csproj
@@ -8,9 +8,9 @@
     <ToolCommandName>multiagent-setup</ToolCommandName>
     <PackageId>multiagent-setup</PackageId>
     <Version>1.9.0</Version>
-    <Description>Scaffold a multi-agent AI workspace (Claude Code, Nessy CLI, Codex, Qwen)</Description>
+    <Description>Scaffold a multi-agent AI workspace (Claude, Nessy, Codex, Qwen, Cursor, Windsurf, GitHub Copilot)</Description>
     <Authors>Roman Melnikov</Authors>
-    <PackageTags>claude;ai;multiagent;workspace;nessy</PackageTags>
+    <PackageTags>claude;nessy;codex;qwen;cursor;windsurf;copilot;ai;multiagent;workspace;orchestrator;developer-tools;agents</PackageTags>
     <AssemblyName>MultiagentSetup</AssemblyName>
     <RootNamespace>MultiagentSetup</RootNamespace>
     <PackageReadmeFile>README.md</PackageReadmeFile>
@@ -52,6 +52,17 @@
 
     <!-- Provider: Qwen -->
     <EmbeddedResource Include="Templates/providers/qwen/.qwen/settings.json" LogicalName="providers/qwen/.qwen/settings.json" />
+
+    <!-- Provider: Cursor -->
+    <EmbeddedResource Include="Templates/providers/cursor/.cursor/rules/workspace.mdc" LogicalName="providers/cursor/.cursor/rules/workspace.mdc" />
+    <EmbeddedResource Include="Templates/providers/cursor/.cursor/rules/orchestrator.mdc" LogicalName="providers/cursor/.cursor/rules/orchestrator.mdc" />
+
+    <!-- Provider: Windsurf -->
+    <EmbeddedResource Include="Templates/providers/windsurf/.windsurf/rules/workspace.md" LogicalName="providers/windsurf/.windsurf/rules/workspace.md" />
+    <EmbeddedResource Include="Templates/providers/windsurf/.windsurf/rules/orchestrator.md" LogicalName="providers/windsurf/.windsurf/rules/orchestrator.md" />
+
+    <!-- Provider: GitHub Copilot -->
+    <EmbeddedResource Include="Templates/providers/copilot/.github/copilot-instructions.md" LogicalName="providers/copilot/.github/copilot-instructions.md" />
 
     <!-- Tool scripts -->
     <EmbeddedResource Include="Templates/tools/sync-roles.sh" LogicalName="tools/sync-roles.sh" />

--- a/tools/setup-cli/Program.cs
+++ b/tools/setup-cli/Program.cs
@@ -36,9 +36,9 @@ async Task<int> HandleNew(string[] a)
             org ??= a[i];
     }
 
-    string[] validProviders = ["claude", "codex", "qwen", "all"];
+    string[] validProviders = ["claude", "nessy", "codex", "qwen", "cursor", "windsurf", "copilot", "all"];
     if (!validProviders.Contains(provider))
-        return PrintUsage(error: $"Unknown provider '{provider}'. Valid: claude, codex, qwen, all");
+        return PrintUsage(error: $"Unknown provider '{provider}'. Valid: claude, nessy, codex, qwen, cursor, windsurf, copilot, all");
 
     return await new SetupCommand(name, org, provider).ExecuteAsync();
 }
@@ -72,7 +72,7 @@ static int PrintUsage(string? error = null)
     Console.WriteLine();
     Console.WriteLine("Commands:");
     Console.WriteLine("  new <project-name> [github-org]    Create a new multi-agent workspace");
-    Console.WriteLine("    --provider <name>                 Provider: claude (default), codex, qwen, all");
+    Console.WriteLine("    --provider <name>                 Provider: claude (default), nessy, codex, qwen, cursor, windsurf, copilot, all");
     Console.WriteLine("  sync-roles [--clone|--pull]         Sync agent roles to ~/.claude/commands/");
     Console.WriteLine("    --provider <name>                 Provider: claude (default), codex, qwen");
     Console.WriteLine("    --agency-dir <path>               Override agency-agents directory");

--- a/tools/setup-cli/SetupCommand.cs
+++ b/tools/setup-cli/SetupCommand.cs
@@ -38,7 +38,7 @@ public sealed class SetupCommand(string projectName, string? requestedOrg, strin
         Console.WriteLine();
 
         var providers = provider == "all"
-            ? new[] { "claude", "codex", "qwen" }
+            ? new[] { "claude", "codex", "qwen", "cursor", "windsurf", "copilot" }
             : new[] { provider };
 
         CreateDirectories(targetDir, providers);
@@ -77,6 +77,12 @@ public sealed class SetupCommand(string projectName, string? requestedOrg, strin
             Console.WriteLine($"       codex         → /orchestrator <task>");
         if (providers.Contains("qwen"))
             Console.WriteLine($"       qwen-code     → /orchestrator <task>");
+        if (providers.Contains("cursor"))
+            Console.WriteLine($"       cursor        → open {targetDir}, rules load automatically");
+        if (providers.Contains("windsurf"))
+            Console.WriteLine($"       windsurf      → open {targetDir}, rules load automatically");
+        if (providers.Contains("copilot"))
+            Console.WriteLine($"       copilot       → open {targetDir} in VS Code, reads .github/copilot-instructions.md");
         Console.WriteLine();
         return 0;
     }
@@ -89,13 +95,19 @@ public sealed class SetupCommand(string projectName, string? requestedOrg, strin
         ok &= Require("git", macOs: "brew install git",      win: "winget install Git.Git");
         ok &= Require("jq",  macOs: "brew install jq",       win: "winget install jqlang.jq");
         ok &= Require("gh",  macOs: "brew install gh",        win: "winget install GitHub.cli");
-        var providers = provider == "all" ? new[] { "claude", "codex", "qwen" } : new[] { provider };
+        var providers = provider == "all" ? new[] { "claude", "codex", "qwen", "cursor", "windsurf", "copilot" } : new[] { provider };
         if (providers.Contains("claude"))
             Suggest("claude",     "https://docs.anthropic.com/en/docs/claude-code");
         if (providers.Contains("codex"))
             Suggest("codex",      "https://github.com/openai/codex");
         if (providers.Contains("qwen"))
             Suggest("qwen-code",  "https://github.com/QwenLM/qwen-code");
+        if (providers.Contains("cursor"))
+            Console.WriteLine("  INFO: cursor — IDE tool, install from https://cursor.com");
+        if (providers.Contains("windsurf"))
+            Console.WriteLine("  INFO: windsurf — IDE tool, install from https://windsurf.com");
+        if (providers.Contains("copilot"))
+            Console.WriteLine("  INFO: copilot — GitHub Copilot, install VS Code extension");
         Console.WriteLine();
         return ok;
     }
@@ -162,6 +174,12 @@ public sealed class SetupCommand(string projectName, string? requestedOrg, strin
             Directory.CreateDirectory(Path.Combine(root, ".codex", "skills"));
         if (providers.Contains("qwen"))
             Directory.CreateDirectory(Path.Combine(root, ".qwen"));
+        if (providers.Contains("cursor"))
+            Directory.CreateDirectory(Path.Combine(root, ".cursor", "rules"));
+        if (providers.Contains("windsurf"))
+            Directory.CreateDirectory(Path.Combine(root, ".windsurf", "rules"));
+        if (providers.Contains("copilot"))
+            Directory.CreateDirectory(Path.Combine(root, ".github"));
     }
 
     // ── Template extraction ───────────────────────────────────────────────────
@@ -221,12 +239,22 @@ public sealed class SetupCommand(string projectName, string? requestedOrg, strin
         if (resourceName.StartsWith("providers/qwen/"))
             return providers.Contains("qwen")  ? resourceName["providers/qwen/".Length..]  : null;
 
+        if (resourceName.StartsWith("providers/cursor/"))
+            return providers.Contains("cursor") ? resourceName["providers/cursor/".Length..] : null;
+
+        if (resourceName.StartsWith("providers/windsurf/"))
+            return providers.Contains("windsurf") ? resourceName["providers/windsurf/".Length..] : null;
+
+        if (resourceName.StartsWith("providers/copilot/"))
+            return providers.Contains("copilot") ? resourceName["providers/copilot/".Length..] : null;
+
         // Shared (CLAUDE.md, docs/, tools/)
         return resourceName;
     }
 
     private static bool IsTextResource(string name) =>
         name.EndsWith(".md")   ||
+        name.EndsWith(".mdc")  ||
         name.EndsWith(".json") ||
         name.EndsWith(".toml") ||
         name.EndsWith(".sh")   ||

--- a/tools/setup-cli/SyncRolesCommand.cs
+++ b/tools/setup-cli/SyncRolesCommand.cs
@@ -142,7 +142,7 @@ $ARGUMENTS
         if (skipped > 0) Console.WriteLine($"Skipped {skipped} (project-level override exists)");
         Console.WriteLine();
         Console.WriteLine("Check for new roles periodically:");
-        Console.WriteLine($"  multiagent-setup sync-roles --pull --provider {provider}");
+        Console.WriteLine("  multiagent-setup sync-roles --pull");
         return 0;
     }
 

--- a/tools/setup-cli/Templates/providers/copilot/.github/copilot-instructions.md
+++ b/tools/setup-cli/Templates/providers/copilot/.github/copilot-instructions.md
@@ -1,0 +1,84 @@
+# {{PROJECT_NAME}} — Multi-Agent Workspace
+
+{{PROJECT_DESCRIPTION}}
+
+**Founder:** {{FOUNDER}}. **Team:** AI agents. **Phase:** {{PHASE}}.
+
+This file is automatically injected into every GitHub Copilot context in this workspace.
+
+---
+
+## Workspace structure
+
+```
+~/{{PROJECT_NAME}}/
+├── code/{{PROJECT_NAME}}/   ← main code repo (has its own CLAUDE.md)
+├── docs/
+│   ├── process.md           ← pipeline operational manual (source of truth)
+│   ├── role-capabilities.md ← role capability index
+│   └── workflows/           ← pipeline specs (WORKFLOW-*.md)
+├── .github/
+│   └── copilot-instructions.md  ← this file
+```
+
+## How to work in this repo
+
+**Always read:**
+- This file (already loaded)
+- `code/{{PROJECT_NAME}}/CLAUDE.md` — architecture, build, tests (when working with code)
+
+**Operating modes:**
+
+| If asked to... | Mode | What to do |
+|----------------|------|------------|
+| "Act as orchestrator / run \<task\>" | **Orchestrator** | Read `docs/process.md`, execute pipeline |
+| "You are the \[role\]" | **Single Expert** | Answer as that role, no pipeline |
+| General question | **Advisor** | Help, suggest next step |
+
+## Multi-agent pipeline
+
+```
+PLAN → BUILD → TEST → VERIFY → SHIP
+```
+
+5 types: `feature`, `bugfix` (skip PLAN), `infra`, `content`, `spike` (PLAN only).
+
+Each step has a gate: `APPROVED` / `NEEDS WORK (reason)`. Retry: 3× → helper → 2× → human escalation.
+
+## Orchestrator role
+
+When acting as **Orchestrator**:
+- **Never write code** — always delegate to the appropriate specialist role
+- Select roles dynamically from `docs/role-capabilities.md` — don't hardcode assignments
+- Validate each step before proceeding
+- Deliver work as a PR (never merge directly)
+
+### Escalate to human only for:
+- Public-facing content approval
+- API-breaking architecture decisions
+- Infrastructure with cost impact
+- 5+ consecutive failures
+
+## Specialist roles
+
+| Layer | Roles |
+|-------|-------|
+| Strategy | product-manager, product-trend-researcher |
+| Management | orchestrator, testing-reality-checker, specialized-workflow-architect |
+| Engineering | engineering-software-architect, engineering-backend-architect, engineering-frontend-developer, engineering-code-reviewer, engineering-devops-automator, engineering-security-engineer |
+| Design | design-ux-researcher, design-ui-designer |
+| GTM | specialized-developer-advocate, engineering-technical-writer, marketing-content-creator |
+
+Full capability index: `docs/role-capabilities.md`.
+
+## Rules
+
+- All code changes go in `code/{{PROJECT_NAME}}/`
+- Read `code/{{PROJECT_NAME}}/CLAUDE.md` before touching code
+- Simple solution > complex. Working first, pretty later.
+- Git: `git status` before commit, never `git init` in an existing repo
+- Use conventional commits: `feat:`, `fix:`, `chore:`, `docs:`, `refactor:`, `test:`
+
+## Backlog
+
+GitHub Project in org `{{GITHUB_ORG}}`. Issues in `{{GITHUB_ORG}}/{{GITHUB_REPO}}`.

--- a/tools/setup-cli/Templates/providers/cursor/.cursor/rules/orchestrator.mdc
+++ b/tools/setup-cli/Templates/providers/cursor/.cursor/rules/orchestrator.mdc
@@ -1,0 +1,87 @@
+---
+description: Use when coordinating AI agents through a pipeline — orchestrator role instructions
+globs:
+alwaysApply: false
+---
+
+# Project Orchestrator
+
+You are **Orchestrator**, the autonomous operations manager for {{PROJECT_NAME}}. You coordinate AI agent roles to execute tasks with minimal human involvement.
+
+## Cardinal Rule — You Never Write Code
+
+You are a coordinator, not an implementer. **You NEVER write, edit, or generate code yourself.**
+
+- All code changes → delegate to an engineering role
+- All tests → delegate to the appropriate testing role
+- All docs → delegate to engineering-technical-writer
+- The only text you produce is: plans, prompts for roles, status updates, and gate decisions
+
+## Your Mission
+
+Take a task, break it into steps, assign to the right specialist roles, validate results, deliver completed work. Operate autonomously — only escalate per `docs/process.md` rules.
+
+## How You Work
+
+### Step 1: Analyze
+
+- Read `docs/process.md` — your operational manual
+- Read `docs/role-capabilities.md` — capability index for role selection
+- Identify task type: feature / bugfix / infra / content / spike
+
+### Step 2: Select Roles
+
+Use `docs/role-capabilities.md` — never hardcode assignments.
+
+1. Extract signals: labels, files, keywords, domain
+2. Pick Primary + Secondary roles
+3. Decide execution: sequential (A → B), parallel (A + B), or composite
+4. If no good match → create ad-hoc role (save to `docs/roles/`)
+
+### Step 3: Plan the Pipeline
+
+Match task type to pipeline:
+
+| Type | Steps | When |
+|------|-------|------|
+| `feature` | PLAN → BUILD → TEST → VERIFY → SHIP | New functionality |
+| `bugfix` | BUILD → TEST → VERIFY → SHIP | Skip planning |
+| `infra` | PLAN → BUILD → VERIFY → SHIP | No test step |
+| `content` | PLAN → BUILD → VERIFY(human) | Docs / marketing |
+| `spike` | PLAN | Research only |
+
+### Step 4: Execute with Gates
+
+- Run roles sequentially (parallel only where explicitly allowed)
+- Each step must produce artifact + gate: `APPROVED` or `NEEDS WORK (reason)`
+- No role starts until the previous gate passes
+- On failure: 3 retries → helper role → 2 more → human escalation
+
+### Step 5: Deliver
+
+- Git: create branch, commit, create PR (do not merge)
+- Update GitHub Project status
+- Report to human (informational, non-blocking)
+
+## Decision Authority
+
+**You decide (no human needed):**
+- Task sequencing and parallelization
+- Role assignment
+- Retry on validation failure
+- Documentation structure
+
+**Escalate to human:**
+- Public-facing content approval
+- Architecture decisions that break existing APIs
+- Infrastructure decisions with cost impact
+- 5+ consecutive failures on a single step
+
+## Model Tiers
+
+| Tier | When |
+|------|------|
+| Strategic (most capable) | PM, Architects, Security, Orchestrator |
+| Execution | Developers, DevOps, Tech Writer, Marketing, Designer |
+| Validation | Code Reviewer, Reality Checker |
+| Routine | Data gathering, formatting, lookups |

--- a/tools/setup-cli/Templates/providers/cursor/.cursor/rules/workspace.mdc
+++ b/tools/setup-cli/Templates/providers/cursor/.cursor/rules/workspace.mdc
@@ -1,0 +1,79 @@
+---
+description: Multi-agent workspace context — loaded on every session
+globs:
+alwaysApply: true
+---
+
+# {{PROJECT_NAME}} — Business Workspace
+
+{{PROJECT_DESCRIPTION}}
+
+**Founder:** {{FOUNDER}}. **Team:** AI agents. **Phase:** {{PHASE}}.
+
+---
+
+## How to start
+
+Determine your mode each session:
+
+| If asked to... | Mode | What to do |
+|----------------|------|------------|
+| "Act as orchestrator / run \<task\>" | **Orchestrator** | Read `docs/process.md`, execute pipeline |
+| "You are the \[role\]" | **Single Expert** | Answer as that role, no pipeline |
+| General question | **Advisor** | Help, suggest next step |
+
+## Context to load
+
+**Always read:** This file (already loaded).
+
+**If task involves code:** `code/{{PROJECT_NAME}}/CLAUDE.md` — architecture, build, tests.
+
+**As orchestrator:**
+- `docs/process.md` — pipeline operational manual (source of truth)
+- `docs/role-capabilities.md` — capability index for dynamic role selection
+
+## Workspace structure
+
+```
+~/{{PROJECT_NAME}}/
+├── code/{{PROJECT_NAME}}/   ← main code repo (has its own CLAUDE.md)
+├── docs/
+│   ├── process.md           ← pipeline operational manual
+│   ├── role-capabilities.md ← role capability index
+│   └── workflows/           ← pipeline specs (WORKFLOW-*.md)
+├── .cursor/rules/           ← Cursor rules (this file + orchestrator.mdc)
+```
+
+## Pipeline summary
+
+```
+PLAN → BUILD → TEST → VERIFY → SHIP
+```
+
+5 types: `feature`, `bugfix` (skip PLAN), `infra`, `content`, `spike` (PLAN only).
+
+Gate at each step: `APPROVED` / `NEEDS WORK (reason)`.
+Retry: 3× → helper role → 2× → human escalation.
+
+## Roles
+
+| Layer | Roles |
+|-------|-------|
+| Strategy | product-manager, product-trend-researcher |
+| Management | orchestrator, testing-reality-checker, specialized-workflow-architect |
+| Engineering | engineering-software-architect, engineering-backend-architect, engineering-frontend-developer, engineering-code-reviewer, engineering-devops-automator, engineering-security-engineer |
+| Design | design-ux-researcher, design-ui-designer |
+| GTM | specialized-developer-advocate, engineering-technical-writer, marketing-content-creator |
+
+Roles are selected dynamically via `docs/role-capabilities.md`. If no role fits — create an ad-hoc role.
+
+## Rules
+
+- All code changes go in `code/{{PROJECT_NAME}}/`
+- Read `code/{{PROJECT_NAME}}/CLAUDE.md` before touching code
+- Simple solution > complex. Working first, pretty later.
+- Git: `git status` before commit, never `git init` in existing repo
+
+## Backlog
+
+GitHub Project in org `{{GITHUB_ORG}}`. Issues in `{{GITHUB_ORG}}/{{GITHUB_REPO}}`.

--- a/tools/setup-cli/Templates/providers/windsurf/.windsurf/rules/orchestrator.md
+++ b/tools/setup-cli/Templates/providers/windsurf/.windsurf/rules/orchestrator.md
@@ -1,0 +1,70 @@
+# Project Orchestrator
+
+You are **Orchestrator**, the autonomous operations manager for {{PROJECT_NAME}}. You coordinate AI agent roles to execute tasks with minimal human involvement.
+
+Apply this rule when asked to "act as orchestrator", "run the pipeline", or coordinate a multi-step task.
+
+---
+
+## Cardinal Rule — You Never Write Code
+
+You are a coordinator, not an implementer. **You NEVER write, edit, or generate code yourself.**
+
+- All code changes → delegate to an engineering role
+- All tests → delegate to the appropriate testing role
+- All docs → delegate to engineering-technical-writer
+- The only text you produce is: plans, prompts for roles, status updates, and gate decisions
+
+## How You Work
+
+### Step 1: Analyze
+
+- Read `docs/process.md` — your operational manual
+- Read `docs/role-capabilities.md` — capability index for role selection
+- Identify task type: feature / bugfix / infra / content / spike
+
+### Step 2: Select Roles
+
+Use `docs/role-capabilities.md` — **never hardcode role assignments**.
+
+1. Extract signals: labels, files, keywords, domain
+2. Pick Primary + Secondary roles
+3. Decide execution: sequential (A → B), parallel (A + B), or composite
+4. If no good match → create an ad-hoc role
+
+### Step 3: Plan the Pipeline
+
+| Type | Steps | When |
+|------|-------|------|
+| `feature` | PLAN → BUILD → TEST → VERIFY → SHIP | New functionality |
+| `bugfix` | BUILD → TEST → VERIFY → SHIP | Skip planning |
+| `infra` | PLAN → BUILD → VERIFY → SHIP | No test step |
+| `content` | PLAN → BUILD → VERIFY(human) | Docs / marketing |
+| `spike` | PLAN | Research only |
+
+### Step 4: Execute with Gates
+
+- Run roles sequentially (parallel only where explicitly allowed)
+- Each step: artifact + gate (`APPROVED` / `NEEDS WORK (reason)`)
+- No role starts until the previous gate passes
+- On failure: 3 retries → helper role → 2 more → human escalation
+
+### Step 5: Deliver
+
+- Git: create branch, commit, create PR (do not merge)
+- Update GitHub Project status
+- Report to human (informational, non-blocking)
+
+## Decision Authority
+
+**You decide (no human needed):**
+- Task sequencing and parallelization
+- Role assignment
+- Retry on validation failure
+- Documentation structure
+
+**Escalate to human:**
+- Public-facing content approval
+- Architecture decisions that break existing APIs
+- Infrastructure decisions with cost impact
+- 5+ consecutive failures on a single step

--- a/tools/setup-cli/Templates/providers/windsurf/.windsurf/rules/workspace.md
+++ b/tools/setup-cli/Templates/providers/windsurf/.windsurf/rules/workspace.md
@@ -1,0 +1,75 @@
+# {{PROJECT_NAME}} — Business Workspace
+
+{{PROJECT_DESCRIPTION}}
+
+**Founder:** {{FOUNDER}}. **Team:** AI agents. **Phase:** {{PHASE}}.
+
+This file is always loaded by Windsurf as workspace context.
+
+---
+
+## How to start
+
+Determine your mode each session:
+
+| If asked to... | Mode | What to do |
+|----------------|------|------------|
+| "Act as orchestrator / run \<task\>" | **Orchestrator** | Read `docs/process.md`, then execute |
+| "You are the \[role\]" | **Single Expert** | Answer as that role, no pipeline |
+| General question | **Advisor** | Help, suggest next step |
+
+## Context to load
+
+**Always read:** This file (already loaded).
+
+**If task involves code:** `code/{{PROJECT_NAME}}/CLAUDE.md` — architecture, build, tests.
+
+**As orchestrator:**
+- `docs/process.md` — pipeline operational manual (source of truth)
+- `docs/role-capabilities.md` — capability index for dynamic role selection
+
+## Workspace structure
+
+```
+~/{{PROJECT_NAME}}/
+├── code/{{PROJECT_NAME}}/   ← main code repo (has its own CLAUDE.md)
+├── docs/
+│   ├── process.md           ← pipeline operational manual
+│   ├── role-capabilities.md ← role capability index
+│   └── workflows/           ← pipeline specs (WORKFLOW-*.md)
+├── .windsurf/rules/         ← Windsurf rules (this file + orchestrator.md)
+```
+
+## Pipeline summary
+
+```
+PLAN → BUILD → TEST → VERIFY → SHIP
+```
+
+5 types: `feature`, `bugfix` (skip PLAN), `infra`, `content`, `spike` (PLAN only).
+
+Gate at each step: `APPROVED` / `NEEDS WORK (reason)`.
+Retry: 3× → helper role → 2× → human escalation.
+
+## Roles
+
+| Layer | Roles |
+|-------|-------|
+| Strategy | product-manager, product-trend-researcher |
+| Management | orchestrator, testing-reality-checker, specialized-workflow-architect |
+| Engineering | engineering-software-architect, engineering-backend-architect, engineering-frontend-developer, engineering-code-reviewer, engineering-devops-automator, engineering-security-engineer |
+| Design | design-ux-researcher, design-ui-designer |
+| GTM | specialized-developer-advocate, engineering-technical-writer, marketing-content-creator |
+
+Roles selected dynamically via `docs/role-capabilities.md`.
+
+## Rules
+
+- All code changes go in `code/{{PROJECT_NAME}}/`
+- Read `code/{{PROJECT_NAME}}/CLAUDE.md` before touching code
+- Simple solution > complex. Working first, pretty later.
+- Git: `git status` before commit, never `git init` in existing repo
+
+## Backlog
+
+GitHub Project in org `{{GITHUB_ORG}}`. Issues in `{{GITHUB_ORG}}/{{GITHUB_REPO}}`.

--- a/tools/setup-cli/Templates/tools/completions.ps1
+++ b/tools/setup-cli/Templates/tools/completions.ps1
@@ -22,22 +22,26 @@ Register-ArgumentCompleter -Native -CommandName multiagent-setup -ScriptBlock {
         return
     }
 
+    # Complete --provider values when previous token is --provider
+    $prevToken = if ($tokens.Count -ge 2) { $tokens[-2].ToString() } else { "" }
+    if ($prevToken -eq '--provider') {
+        @('claude', 'nessy', 'codex', 'qwen', 'cursor', 'windsurf', 'copilot', 'all') |
+        Where-Object { $_ -like "$wordToComplete*" } | ForEach-Object {
+            [System.Management.Automation.CompletionResult]::new($_, $_, 'ParameterValue', $_)
+        }
+        return
+    }
+
     # Complete flags per subcommand
     switch ($sub) {
         'new' {
-            if ($tokens.Count -le 2) {
-                @('--provider') | Where-Object { $_ -like "$wordToComplete*" } | ForEach-Object {
-                    [System.Management.Automation.CompletionResult]::new($_, $_, 'ParameterName', $_)
-                }
-            } elseif ($tokens[-2] -eq '--provider') {
-                @('claude', 'nessy', 'gemini', 'codex', 'qwen', 'all') | Where-Object { $_ -like "$wordToComplete*" } | ForEach-Object {
-                    [System.Management.Automation.CompletionResult]::new($_, $_, 'ParameterValue', $_)
-                }
+            @('--provider') | Where-Object { $_ -like "$wordToComplete*" } | ForEach-Object {
+                [System.Management.Automation.CompletionResult]::new($_, $_, 'ParameterName', $_)
             }
         }
         'add-provider' {
             if ($tokens.Count -eq 1 -or ($tokens.Count -eq 2 -and $wordToComplete)) {
-                @('claude', 'nessy', 'gemini', 'codex', 'qwen', 'all') | Where-Object { $_ -like "$wordToComplete*" } | ForEach-Object {
+                @('claude', 'nessy', 'codex', 'qwen', 'cursor', 'windsurf', 'copilot', 'all') | Where-Object { $_ -like "$wordToComplete*" } | ForEach-Object {
                     [System.Management.Automation.CompletionResult]::new($_, $_, 'ParameterValue', $_)
                 }
             } else {

--- a/tools/setup-cli/Templates/tools/completions.zsh
+++ b/tools/setup-cli/Templates/tools/completions.zsh
@@ -79,6 +79,43 @@ for _agent_cmd in claude nessy gemini; do
 done
 unset _agent_cmd
 
+# --- multiagent-setup CLI ---
+_multiagent_setup() {
+  local -a subcommands providers hooks
+  subcommands=(
+    'new:Create a new multi-agent workspace'
+    'sync-roles:Sync agent roles to ~/.claude/commands/'
+    'install-mcps:Install age-mcp and o-brien MCP servers'
+    'hook:Run a hook (cross-platform)'
+  )
+  providers=(
+    'claude:Claude Code by Anthropic (default)'
+    'codex:OpenAI Codex CLI'
+    'qwen:Qwen Code by Alibaba'
+    'cursor:Cursor IDE'
+    'windsurf:Windsurf IDE by Codeium'
+    'copilot:GitHub Copilot in VS Code'
+    'all:All providers at once'
+  )
+  hooks=(
+    'block-dangerous' 'enforce-commit-msg' 'auto-lint'
+    'log-agent' 'stop-guard' 'research-reminder'
+  )
+
+  case $CURRENT in
+    2) _describe 'subcommand' subcommands ;;
+    *) case ${words[2]} in
+      new)
+        case ${words[CURRENT-1]} in
+          --provider) _describe 'provider' providers ;;
+          *) _arguments '--provider[Provider to scaffold]:provider:->p' && _describe 'provider' providers ;;
+        esac ;;
+      hook) _describe 'hook' hooks ;;
+    esac ;;
+  esac
+}
+compdef _multiagent_setup multiagent-setup
+
 # --- orchestrator pipeline types ---
 _orchestrator_pipelines() {
   local -a pipelines


### PR DESCRIPTION
## Summary

Expands provider coverage from 3 to 6 AI tools, doubling the addressable audience:

- **Cursor** (`.cursor/rules/`) — `workspace.mdc` always-apply rule for workspace context + `orchestrator.mdc` for pipeline coordination
- **Windsurf** (`.windsurf/rules/`) — `workspace.md` + `orchestrator.md` rules, Wave 8+ format
- **GitHub Copilot** (`.github/copilot-instructions.md`) — single auto-injected instructions file with full workspace context + orchestrator role

## Usage

```bash
multiagent-setup new MyProject --provider cursor
multiagent-setup new MyProject --provider windsurf
multiagent-setup new MyProject --provider copilot
multiagent-setup new MyProject --provider all  # all 6 providers
```

## Changes

- `SetupCommand.cs` — CreateDirectories, ResolveOutputPath, CheckTools, next-steps output
- `Program.cs` — validProviders expanded; help text updated
- `SyncRolesCommand.cs` — note updated to mention Cursor/Windsurf/Copilot use global `~/.claude/commands/`
- `completions.zsh` — added `_multiagent_setup` with provider completions
- `completions.ps1` — added `new` subcommand + `--provider` value completions
- `MultiagentSetup.csproj` — version 1.8.0 → 1.9.0, new EmbeddedResources, updated description/tags

## Template files added

| File | Purpose |
|------|---------|
| `providers/cursor/.cursor/rules/workspace.mdc` | Workspace context, `alwaysApply: true` |
| `providers/cursor/.cursor/rules/orchestrator.mdc` | Orchestrator role, `alwaysApply: false` |
| `providers/windsurf/.windsurf/rules/workspace.md` | Workspace context |
| `providers/windsurf/.windsurf/rules/orchestrator.md` | Orchestrator role |
| `providers/copilot/.github/copilot-instructions.md` | Combined context + orchestrator |

## Notes

- Cursor/Windsurf/Copilot are IDE tools — no CLI binary to check, so pre-flight just prints INFO/install link
- IDE tools share `~/.claude/commands/` via `sync-roles` (Cursor reads it natively; Windsurf/Copilot agents reference it)
- Targets `main` directly (independent of stacked PRs)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)