### PR TITLE
feat: add --provider nessy support (Claude alias)

### DIFF
--- a/tools/setup-cli/Program.cs
+++ b/tools/setup-cli/Program.cs
@@ -36,9 +36,9 @@ async Task<int> HandleNew(string[] a)
             org ??= a[i];
     }
 
-    string[] validProviders = ["claude", "codex", "qwen", "all"];
+    string[] validProviders = ["claude", "nessy", "codex", "qwen", "all"];
     if (!validProviders.Contains(provider))
-        return PrintUsage(error: $"Unknown provider '{provider}'. Valid: claude, codex, qwen, all");
+        return PrintUsage(error: $"Unknown provider '{provider}'. Valid: claude, nessy, codex, qwen, all");
 
     return await new SetupCommand(name, org, provider).ExecuteAsync();
 }
@@ -66,7 +66,7 @@ static int PrintUsage(string? error = null)
     Console.WriteLine();
     Console.WriteLine("Commands:");
     Console.WriteLine("  new <project-name> [github-org]    Create a new multi-agent workspace");
-    Console.WriteLine("    --provider <name>                 Provider: claude (default), codex, qwen, all");
+    Console.WriteLine("    --provider <name>                 Provider: claude (default), nessy, codex, qwen, all");
     Console.WriteLine("  sync-roles [--clone|--pull]         Sync agent roles to ~/.claude/commands/");
     Console.WriteLine("    --agency-dir <path>               Override agency-agents directory");
     Console.WriteLine("  install-mcps [options]              Install age-mcp and o-brien MCP servers");

--- a/tools/setup-cli/SetupCommand.cs
+++ b/tools/setup-cli/SetupCommand.cs
@@ -38,7 +38,7 @@ public sealed class SetupCommand(string projectName, string? requestedOrg, strin
         Console.WriteLine();
 
         var providers = provider == "all"
-            ? new[] { "claude", "codex", "qwen" }
+            ? new[] { "claude", "nessy", "codex", "qwen" }
             : new[] { provider };
 
         CreateDirectories(targetDir, providers);
@@ -53,7 +53,7 @@ public sealed class SetupCommand(string projectName, string? requestedOrg, strin
             Console.WriteLine("  OK: permissions set");
         }
 
-        if (providers.Contains("claude"))
+        if (providers.Contains("claude") || providers.Contains("nessy"))
             await SetupAgencyRolesAsync(targetDir);
         await GitInitAsync(targetDir);
         Console.WriteLine("  OK: git initialized");
@@ -72,6 +72,11 @@ public sealed class SetupCommand(string projectName, string? requestedOrg, strin
             Console.WriteLine($"  4. (Optional) Update roles: multiagent-setup sync-roles --pull");
             Console.WriteLine($"  5. Start working: claude then /orchestrator <task>");
         }
+        if (providers.Contains("nessy"))
+        {
+            Console.WriteLine($"  4. (Optional) Update roles: multiagent-setup sync-roles --pull");
+            Console.WriteLine($"  5. Start working: nessy then /orchestrator <task>");
+        }
         if (providers.Contains("codex"))
             Console.WriteLine($"  5. Start working: codex then /orchestrator <task>");
         if (providers.Contains("qwen"))
@@ -88,9 +93,11 @@ public sealed class SetupCommand(string projectName, string? requestedOrg, strin
         ok &= Require("git");
         ok &= Require("jq");
         ok &= Require("gh");
-        var providers = provider == "all" ? new[] { "claude", "codex", "qwen" } : new[] { provider };
+        var providers = provider == "all" ? new[] { "claude", "nessy", "codex", "qwen" } : new[] { provider };
         if (providers.Contains("claude"))
             Suggest("claude",     "https://docs.anthropic.com/en/docs/claude-code");
+        if (providers.Contains("nessy"))
+            Suggest("nessy",      "https://github.com/Neftedollar/nessy");
         if (providers.Contains("codex"))
             Suggest("codex",      "https://github.com/openai/codex");
         if (providers.Contains("qwen"))
@@ -150,7 +157,7 @@ public sealed class SetupCommand(string projectName, string? requestedOrg, strin
         foreach (var d in new[] { "code", "docs/workflows", "docs/archive", "docs/obsolete-docs", "tools" })
             Directory.CreateDirectory(Path.Combine(root, d.Replace('/', Path.DirectorySeparatorChar)));
 
-        if (providers.Contains("claude"))
+        if (providers.Contains("claude") || providers.Contains("nessy"))
         {
             Directory.CreateDirectory(Path.Combine(root, ".claude", "commands"));
             Directory.CreateDirectory(Path.Combine(root, ".claude", "hooks"));
@@ -210,7 +217,7 @@ public sealed class SetupCommand(string projectName, string? requestedOrg, strin
     private static string? ResolveOutputPath(string resourceName, string[] providers)
     {
         if (resourceName.StartsWith(".claude/"))
-            return providers.Contains("claude") ? resourceName : null;
+            return (providers.Contains("claude") || providers.Contains("nessy")) ? resourceName : null;
 
         if (resourceName.StartsWith("providers/codex/"))
             return providers.Contains("codex") ? resourceName["providers/codex/".Length..] : null;


### PR DESCRIPTION
## Summary

Adds `--provider nessy` as a valid provider. Nessy is a Claude-compatible agent that reuses the same `.claude/` configuration — same `CLAUDE.md`, same hooks, same slash commands, just a different binary name (`nessy`).

```bash
multiagent-setup new MyProject --provider nessy
# → scaffolds .claude/ config, CLAUDE.md, hooks — identical to --provider claude
# → next step shows: "nessy then /orchestrator <task>"
```

**`--provider all`** now also includes nessy.

## Changes

- `Program.cs` — `nessy` added to `validProviders`; help text updated
- `SetupCommand.cs`:
  - `CreateDirectories`: creates `.claude/` dirs when nessy selected
  - `SetupAgencyRolesAsync`: called for nessy (syncs roles to `~/.claude/commands/`)
  - `ResolveOutputPath`: `.claude/` templates extracted for nessy
  - `CheckTools`: suggests nessy install URL
  - Next-steps output: shows `nessy then /orchestrator <task>`

## Notes

Nessy provider was already documented in the README but the CLI rejected `--provider nessy` with an error. This makes it work.

Targets main directly (independent of stacked PRs #3, #19 which also add nessy but with more changes).

🤖 Generated with [Claude Code](https://claude.ai/claude-code)