### PR TITLE
fix: escape zsh completion path against shell injection

### DIFF
--- a/tools/setup-cli/SetupCommand.cs
+++ b/tools/setup-cli/SetupCommand.cs
@@ -291,8 +291,10 @@ public sealed class SetupCommand(string projectName, string? requestedOrg, strin
         if (key.KeyChar is 'y' or 'Y')
         {
             var completionsPath = Path.Combine(workspaceRoot, "tools", "completions.zsh");
+            // Single-quote the path to prevent shell interpretation of special characters
+            var escapedPath = completionsPath.Replace("'", "'\\''");
             await File.AppendAllTextAsync(zshrc,
-                $"\n# Multi-agent workspace completions\nsource \"{completionsPath}\"\n");
+                $"\n# Multi-agent workspace completions\nsource -- '{escapedPath}'\n");
             Console.WriteLine("  OK: completions added (restart shell or: source ~/.zshrc)");
         }
     }


### PR DESCRIPTION
## Summary

Fixes potential shell injection in `OfferCompletionsUnixAsync`.

**Before:**
```csharp
$"\nsource \"{completionsPath}\"\n"
```
A workspace directory named e.g. `$(malicious-cmd)` would be executed when the user sources `.zshrc`.

**After:**
```csharp
var escapedPath = completionsPath.Replace("'", "'\\''");
$"\nsource -- '{escapedPath}'\n"
```
Single-quoting prevents `$()`, backtick, `$var`, and all other shell interpretations. The `'\\''` idiom safely handles paths with literal single quotes.

Found during code quality audit. Low-severity (requires user to name their project after a shell command), but cheap to fix.

Targets main directly.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)