### PR TITLE
fix: bootstrap installs .NET 10

### DIFF
--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -66,11 +66,11 @@ Write-Host "  OK: gh"
 if (-not (Has "dotnet")) {
     Write-Host "  ..  Installing .NET SDK..."
     if ($hasWinget) {
-        Install-WinGet "Microsoft.DotNet.SDK.9" ".NET SDK"
+        Install-WinGet "Microsoft.DotNet.SDK.10" ".NET SDK"
     } else {
         $script = "$env:TEMP\dotnet-install.ps1"
         Invoke-WebRequest -Uri "https://dot.net/v1/dotnet-install.ps1" -OutFile $script -UseBasicParsing
-        & $script -Channel LTS
+        & $script -Channel 10.0
         $env:PATH += ";$env:LOCALAPPDATA\Microsoft\dotnet"
     }
 }

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -79,7 +79,7 @@ if ! has dotnet; then
   if [ "$OS" = "Darwin" ]; then
     brew install dotnet
   else
-    curl -fsSL https://dot.net/v1/dotnet-install.sh | bash -s -- --channel LTS
+    curl -fsSL https://dot.net/v1/dotnet-install.sh | bash -s -- --channel 10.0
     export PATH="$HOME/.dotnet:$PATH"
   fi
 fi


### PR DESCRIPTION
## Summary

- `bootstrap.sh`: changes `--channel LTS` → `--channel 10.0` for Linux dotnet-install
- `bootstrap.ps1`: changes `SDK.9` → `SDK.10` (winget) and `-Channel LTS` → `-Channel 10.0`

The tool requires .NET 10, so the bootstrap should install .NET 10 directly instead of LTS (which currently resolves to .NET 8).

## Test plan
- [ ] macOS/Linux: run bootstrap on fresh machine, verify `dotnet --version` shows 10.x
- [ ] Windows: run bootstrap, verify .NET 10 installed via winget