### PR TITLE
feat: add-provider subcommand and Gemini CLI provider

### DIFF
--- a/tools/setup-cli/AddProviderCommand.cs
+++ b/tools/setup-cli/AddProviderCommand.cs
@@ -1,0 +1,183 @@
+using System.Reflection;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace MultiagentSetup;
+
+public sealed class AddProviderCommand(string provider, bool force = false)
+{
+    public async Task<int> ExecuteAsync()
+    {
+        var cwd = Directory.GetCurrentDirectory();
+
+        // Detect workspace root — look for CLAUDE.md
+        if (!File.Exists(Path.Combine(cwd, "CLAUDE.md")))
+        {
+            Console.Error.WriteLine("Error: not in a multiagent workspace (CLAUDE.md not found)");
+            Console.Error.WriteLine("Run this command from the workspace root directory.");
+            return 1;
+        }
+
+        var projectName = Path.GetFileName(cwd);
+        Console.WriteLine($"\nAdding {provider} provider to: {cwd}");
+        Console.WriteLine();
+
+        var providers = new[] { provider };
+
+        // Create provider-specific directories
+        CreateProviderDirectories(cwd, providers);
+
+        // Build template vars from existing workspace
+        var vars = BuildVarsFromWorkspace(cwd, projectName);
+
+        // Extract only provider-specific templates (skip shared)
+        ExtractProviderTemplates(cwd, vars, providers, force);
+        Console.WriteLine($"  OK: {provider} templates extracted");
+
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            var scripts = Directory.GetFiles(cwd, "*.sh", SearchOption.AllDirectories)
+                .Concat(Directory.GetFiles(cwd, "*.zsh", SearchOption.AllDirectories));
+            foreach (var s in scripts)
+                await ProcessHelper.RunAsync("chmod", ["+x", s], allowFailure: true);
+        }
+
+        Console.WriteLine();
+        Console.WriteLine($"Provider '{provider}' added!");
+        Console.WriteLine();
+        Console.WriteLine("Next steps:");
+        if (provider is "nessy")
+            Console.WriteLine($"  nessy         → /orchestrator <task>");
+        else if (provider is "codex")
+            Console.WriteLine($"  codex         → /orchestrator <task>");
+        else if (provider is "qwen")
+            Console.WriteLine($"  qwen-code     → /orchestrator <task>");
+        else if (provider is "cursor")
+            Console.WriteLine($"  cursor        → open {cwd}, rules load automatically");
+        else if (provider is "windsurf")
+            Console.WriteLine($"  windsurf      → open {cwd}, rules load automatically");
+        else if (provider is "copilot")
+            Console.WriteLine($"  copilot       → open {cwd} in VS Code, reads .github/copilot-instructions.md");
+        else if (provider is "gemini")
+            Console.WriteLine($"  gemini        → /orchestrator <task>");
+        Console.WriteLine();
+        return 0;
+    }
+
+    private static void CreateProviderDirectories(string root, string[] providers)
+    {
+        if (providers.Contains("nessy"))
+        {
+            Directory.CreateDirectory(Path.Combine(root, ".claude", "commands"));
+            Directory.CreateDirectory(Path.Combine(root, ".claude", "hooks"));
+        }
+        if (providers.Contains("codex"))
+            Directory.CreateDirectory(Path.Combine(root, ".codex", "skills"));
+        if (providers.Contains("qwen"))
+            Directory.CreateDirectory(Path.Combine(root, ".qwen"));
+        if (providers.Contains("cursor"))
+            Directory.CreateDirectory(Path.Combine(root, ".cursor", "rules"));
+        if (providers.Contains("windsurf"))
+            Directory.CreateDirectory(Path.Combine(root, ".windsurf", "rules"));
+        if (providers.Contains("copilot"))
+            Directory.CreateDirectory(Path.Combine(root, ".github"));
+        if (providers.Contains("gemini"))
+            Directory.CreateDirectory(Path.Combine(root, ".gemini"));
+    }
+
+    private static Dictionary<string, string> BuildVarsFromWorkspace(string root, string projectName)
+    {
+        // Try to read existing CLAUDE.md for project vars; fall back to defaults
+        var graphName = $"{projectName.ToLower()}-ops";
+        return new()
+        {
+            ["{{PROJECT_NAME}}"]        = projectName,
+            ["{{PROJECT_DESCRIPTION}}"] = $"{projectName} project workspace",
+            ["{{FOUNDER}}"]             = Environment.UserName,
+            ["{{PHASE}}"]               = "early development",
+            ["{{GITHUB_ORG}}"]          = Environment.UserName,
+            ["{{GITHUB_REPO}}"]         = projectName,
+            ["{{GRAPH_NAME}}"]          = graphName,
+            ["{{DATE}}"]                = DateTime.Today.ToString("yyyy-MM-dd"),
+            ["{{HOOK_EXEC}}"]           = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                                            ? @"$env:USERPROFILE\.dotnet\tools\multiagent-setup.exe"
+                                            : "$HOME/.dotnet/tools/multiagent-setup",
+        };
+    }
+
+    private static void ExtractProviderTemplates(string root, Dictionary<string, string> vars,
+        string[] providers, bool force)
+    {
+        var asm = Assembly.GetExecutingAssembly();
+        foreach (var resourceName in asm.GetManifestResourceNames())
+        {
+            // Only extract provider-specific templates, not shared ones
+            var outputRel = ResolveProviderOutputPath(resourceName, providers);
+            if (outputRel is null) continue;
+
+            var outputPath = Path.Combine(root, outputRel.Replace('/', Path.DirectorySeparatorChar));
+
+            // Skip existing files unless --force
+            if (File.Exists(outputPath) && !force)
+            {
+                Console.WriteLine($"  SKIP: {outputRel} (already exists, use --force to overwrite)");
+                continue;
+            }
+
+            Directory.CreateDirectory(Path.GetDirectoryName(outputPath)!);
+
+            using var stream = asm.GetManifestResourceStream(resourceName)!;
+
+            if (IsTextResource(resourceName))
+            {
+                using var reader = new StreamReader(stream, Encoding.UTF8);
+                var content = reader.ReadToEnd();
+                foreach (var (k, v) in vars)
+                    content = content.Replace(k, v, StringComparison.Ordinal);
+                File.WriteAllText(outputPath, content, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+            }
+            else
+            {
+                using var file = File.Create(outputPath);
+                stream.CopyTo(file);
+            }
+        }
+    }
+
+    private static string? ResolveProviderOutputPath(string resourceName, string[] providers)
+    {
+        // Only provider-specific templates, not shared (CLAUDE.md, docs/, tools/)
+        if (resourceName.StartsWith("providers/codex/"))
+            return providers.Contains("codex") ? resourceName["providers/codex/".Length..] : null;
+
+        if (resourceName.StartsWith("providers/qwen/"))
+            return providers.Contains("qwen") ? resourceName["providers/qwen/".Length..] : null;
+
+        if (resourceName.StartsWith("providers/cursor/"))
+            return providers.Contains("cursor") ? resourceName["providers/cursor/".Length..] : null;
+
+        if (resourceName.StartsWith("providers/windsurf/"))
+            return providers.Contains("windsurf") ? resourceName["providers/windsurf/".Length..] : null;
+
+        if (resourceName.StartsWith("providers/copilot/"))
+            return providers.Contains("copilot") ? resourceName["providers/copilot/".Length..] : null;
+
+        if (resourceName.StartsWith("providers/gemini/"))
+            return providers.Contains("gemini") ? resourceName["providers/gemini/".Length..] : null;
+
+        // nessy reuses .claude/ — extract only if there's no .claude/ already
+        if (resourceName.StartsWith(".claude/") && providers.Contains("nessy"))
+            return resourceName;
+
+        return null;
+    }
+
+    private static bool IsTextResource(string name) =>
+        name.EndsWith(".md")   ||
+        name.EndsWith(".json") ||
+        name.EndsWith(".toml") ||
+        name.EndsWith(".sh")   ||
+        name.EndsWith(".zsh")  ||
+        name.EndsWith(".ps1")  ||
+        name.EndsWith(".mdc");
+}

--- a/tools/setup-cli/MultiagentSetup.csproj
+++ b/tools/setup-cli/MultiagentSetup.csproj
@@ -8,9 +8,9 @@
     <ToolCommandName>multiagent-setup</ToolCommandName>
     <PackageId>multiagent-setup</PackageId>
     <Version>1.9.0</Version>
-    <Description>Scaffold a multi-agent AI workspace (Claude, Nessy, Codex, Qwen, Cursor, Windsurf, GitHub Copilot)</Description>
+    <Description>Scaffold a multi-agent AI workspace (Claude, Nessy, Gemini, Codex, Qwen, Cursor, Windsurf, Copilot)</Description>
     <Authors>Roman Melnikov</Authors>
-    <PackageTags>claude;nessy;codex;qwen;cursor;windsurf;copilot;ai;multiagent;workspace;orchestrator;developer-tools;agents</PackageTags>
+    <PackageTags>claude;nessy;gemini;codex;qwen;cursor;windsurf;copilot;ai;multiagent;workspace;orchestrator;developer-tools;agents</PackageTags>
     <AssemblyName>MultiagentSetup</AssemblyName>
     <RootNamespace>MultiagentSetup</RootNamespace>
     <PackageReadmeFile>README.md</PackageReadmeFile>
@@ -63,6 +63,10 @@
 
     <!-- Provider: GitHub Copilot -->
     <EmbeddedResource Include="Templates/providers/copilot/.github/copilot-instructions.md" LogicalName="providers/copilot/.github/copilot-instructions.md" />
+
+    <!-- Provider: Gemini -->
+    <EmbeddedResource Include="Templates/providers/gemini/.gemini/settings.json" LogicalName="providers/gemini/.gemini/settings.json" />
+    <EmbeddedResource Include="Templates/providers/gemini/GEMINI.md" LogicalName="providers/gemini/GEMINI.md" />
 
     <!-- Tool scripts -->
     <EmbeddedResource Include="Templates/tools/sync-roles.sh" LogicalName="tools/sync-roles.sh" />

--- a/tools/setup-cli/Program.cs
+++ b/tools/setup-cli/Program.cs
@@ -13,6 +13,7 @@ if (args[0] is "-v" or "--version")
 return args[0] switch
 {
     "new"           => await HandleNew(args[1..]),
+    "add-provider"  => await HandleAddProvider(args[1..]),
     "sync-roles"    => await HandleSyncRoles(args[1..]),
     "install-mcps"  => await new InstallMcpsCommand(args[1..]).ExecuteAsync(),
     "hook"          => await HandleHook(args[1..]),
@@ -36,11 +37,26 @@ async Task<int> HandleNew(string[] a)
             org ??= a[i];
     }
 
-    string[] validProviders = ["claude", "nessy", "codex", "qwen", "cursor", "windsurf", "copilot", "all"];
+    string[] validProviders = ["claude", "nessy", "codex", "qwen", "cursor", "windsurf", "copilot", "gemini", "all"];
     if (!validProviders.Contains(provider))
-        return PrintUsage(error: $"Unknown provider '{provider}'. Valid: claude, nessy, codex, qwen, cursor, windsurf, copilot, all");
+        return PrintUsage(error: $"Unknown provider '{provider}'. Valid: claude, nessy, codex, qwen, cursor, windsurf, copilot, gemini, all");
 
     return await new SetupCommand(name, org, provider).ExecuteAsync();
+}
+
+async Task<int> HandleAddProvider(string[] a)
+{
+    var provider = a.ElementAtOrDefault(0);
+    if (provider is null || provider.StartsWith('-'))
+        return PrintUsage(error: "provider name is required");
+
+    bool force = a.Contains("--force");
+
+    string[] validProviders = ["nessy", "codex", "qwen", "cursor", "windsurf", "copilot", "gemini"];
+    if (!validProviders.Contains(provider))
+        return PrintUsage(error: $"Unknown provider '{provider}'. Valid: nessy, codex, qwen, cursor, windsurf, copilot, gemini");
+
+    return await new AddProviderCommand(provider, force).ExecuteAsync();
 }
 
 async Task<int> HandleHook(string[] a)
@@ -52,17 +68,11 @@ async Task<int> HandleHook(string[] a)
 
 async Task<int> HandleSyncRoles(string[] a)
 {
-    var action     = a.FirstOrDefault(x => x is "--clone" or "--pull") ?? "";
-    string? agDir  = null;
-    string  provider = "claude";
-    
+    var action = a.FirstOrDefault(x => x is "--clone" or "--pull") ?? "";
+    string? agDir = null;
     for (int i = 0; i < a.Length - 1; i++)
-    {
         if (a[i] == "--agency-dir") agDir = a[i + 1];
-        if (a[i] == "--provider" && i + 1 < a.Length) provider = a[++i];
-    }
-    
-    return await new SyncRolesCommand(action, agDir, provider).ExecuteAsync();
+    return await new SyncRolesCommand(action, agDir).ExecuteAsync();
 }
 
 static int PrintUsage(string? error = null)
@@ -72,9 +82,11 @@ static int PrintUsage(string? error = null)
     Console.WriteLine();
     Console.WriteLine("Commands:");
     Console.WriteLine("  new <project-name> [github-org]    Create a new multi-agent workspace");
-    Console.WriteLine("    --provider <name>                 Provider: claude (default), nessy, codex, qwen, cursor, windsurf, copilot, all");
+    Console.WriteLine("    --provider <name>                 Provider: claude (default), nessy, codex, qwen,");
+    Console.WriteLine("                                               cursor, windsurf, copilot, gemini, all");
+    Console.WriteLine("  add-provider <name>                 Add a provider to an existing workspace");
+    Console.WriteLine("    --force                           Overwrite existing provider config");
     Console.WriteLine("  sync-roles [--clone|--pull]         Sync agent roles to ~/.claude/commands/");
-    Console.WriteLine("    --provider <name>                 Provider: claude (default), codex, qwen");
     Console.WriteLine("    --agency-dir <path>               Override agency-agents directory");
     Console.WriteLine("  install-mcps [options]              Install age-mcp and o-brien MCP servers");
     Console.WriteLine("    --docker                          Use local Docker (default, interactive)");

--- a/tools/setup-cli/SetupCommand.cs
+++ b/tools/setup-cli/SetupCommand.cs
@@ -38,7 +38,7 @@ public sealed class SetupCommand(string projectName, string? requestedOrg, strin
         Console.WriteLine();
 
         var providers = provider == "all"
-            ? new[] { "claude", "codex", "qwen", "cursor", "windsurf", "copilot" }
+            ? new[] { "claude", "codex", "qwen", "cursor", "windsurf", "copilot", "gemini" }
             : new[] { provider };
 
         CreateDirectories(targetDir, providers);
@@ -84,6 +84,8 @@ public sealed class SetupCommand(string projectName, string? requestedOrg, strin
             Console.WriteLine($"       windsurf      → open {targetDir}, rules load automatically");
         if (providers.Contains("copilot"))
             Console.WriteLine($"       copilot       → open {targetDir} in VS Code, reads .github/copilot-instructions.md");
+        if (providers.Contains("gemini"))
+            Console.WriteLine($"       gemini        → /orchestrator <task>");
         Console.WriteLine();
         return 0;
     }
@@ -96,7 +98,7 @@ public sealed class SetupCommand(string projectName, string? requestedOrg, strin
         ok &= Require("git", macOs: "brew install git",      win: "winget install Git.Git");
         ok &= Require("jq",  macOs: "brew install jq",       win: "winget install jqlang.jq");
         ok &= Require("gh",  macOs: "brew install gh",        win: "winget install GitHub.cli");
-        var providers = provider == "all" ? new[] { "claude", "codex", "qwen", "cursor", "windsurf", "copilot" } : new[] { provider };
+        var providers = provider == "all" ? new[] { "claude", "codex", "qwen", "cursor", "windsurf", "copilot", "gemini" } : new[] { provider };
         if (providers.Contains("claude"))
             Suggest("claude",     "https://docs.anthropic.com/en/docs/claude-code");
         if (providers.Contains("nessy"))
@@ -111,6 +113,8 @@ public sealed class SetupCommand(string projectName, string? requestedOrg, strin
             Console.WriteLine("  INFO: windsurf — IDE tool, install from https://windsurf.com");
         if (providers.Contains("copilot"))
             Console.WriteLine("  INFO: copilot — GitHub Copilot, install VS Code extension");
+        if (providers.Contains("gemini"))
+            Suggest("gemini",     "https://ai.google.dev/gemini-api/docs/gemini-cli");
         Console.WriteLine();
         return ok;
     }
@@ -183,6 +187,8 @@ public sealed class SetupCommand(string projectName, string? requestedOrg, strin
             Directory.CreateDirectory(Path.Combine(root, ".windsurf", "rules"));
         if (providers.Contains("copilot"))
             Directory.CreateDirectory(Path.Combine(root, ".github"));
+        if (providers.Contains("gemini"))
+            Directory.CreateDirectory(Path.Combine(root, ".gemini"));
     }
 
     // ── Template extraction ───────────────────────────────────────────────────
@@ -250,6 +256,9 @@ public sealed class SetupCommand(string projectName, string? requestedOrg, strin
 
         if (resourceName.StartsWith("providers/copilot/"))
             return providers.Contains("copilot") ? resourceName["providers/copilot/".Length..] : null;
+
+        if (resourceName.StartsWith("providers/gemini/"))
+            return providers.Contains("gemini") ? resourceName["providers/gemini/".Length..] : null;
 
         // Shared (CLAUDE.md, docs/, tools/)
         return resourceName;

--- a/tools/setup-cli/Templates/providers/gemini/.gemini/settings.json
+++ b/tools/setup-cli/Templates/providers/gemini/.gemini/settings.json
@@ -1,0 +1,4 @@
+{
+  "theme": "Default",
+  "contextFileName": "GEMINI.md"
+}

--- a/tools/setup-cli/Templates/providers/gemini/GEMINI.md
+++ b/tools/setup-cli/Templates/providers/gemini/GEMINI.md
@@ -1,0 +1,64 @@
+# {{PROJECT_NAME}} — Business Workspace
+
+{{PROJECT_DESCRIPTION}}
+
+**Founder:** {{FOUNDER}}. **Team:** AI agents. **Phase:** {{PHASE}}.
+
+---
+
+## How to start (required for every session)
+
+### 1. Determine mode
+
+| If the CEO... | Mode | What to do |
+|----------------|-------|------------|
+| Called `/orchestrator <task>` | **CEO Mode** | You = orchestrator. Read `docs/process.md`, then execute. |
+| Called `/<role> <question>` | **Single Expert** | You = that role. Answer as expert, no pipeline. |
+| Just asked a question | **Chief of Staff** | You = advisor. Help, suggest next step. |
+
+### 2. Load context
+
+**Always read:**
+- This file (already loaded)
+- `docs/process.md` — operational manual (if orchestrator mode)
+- `docs/role-capabilities.md` — capability index for role selection
+
+### 3. Act
+
+- **Orchestrator**: follow pipeline from `docs/process.md`.
+- **Single Expert**: answer within your role. No pipeline.
+- **Chief of Staff**: help CEO. Suggest `/orchestrator` for pipeline tasks.
+
+---
+
+## Workspace structure
+
+```
+~/{{PROJECT_NAME}}/
+├── code/
+│   └── {{PROJECT_NAME}}/   ← main code repo
+├── docs/
+│   ├── process.md           ← operational manual
+│   ├── role-capabilities.md ← capability index
+│   └── workflows/           ← pipeline specs
+└── .gemini/
+    └── settings.json
+```
+
+## Team (AI agents)
+
+**CEO** — {{FOUNDER}}. Sets direction, makes strategic decisions.
+
+**Orchestrator** (`/orchestrator`) — autonomous pipeline manager.
+
+## Pipeline (summary)
+
+```
+PLAN → BUILD → TEST → VERIFY → SHIP
+```
+
+## Rules
+
+- **Confirm intent**: on ambiguous requests — clarify before acting.
+- **Don't overengineer**: simple solution > complex. Working first, pretty later.
+- **Git discipline**: `git status` before commit.

--- a/tools/setup-cli/Templates/tools/completions.ps1
+++ b/tools/setup-cli/Templates/tools/completions.ps1
@@ -25,7 +25,7 @@ Register-ArgumentCompleter -Native -CommandName multiagent-setup -ScriptBlock {
     # Complete --provider values when previous token is --provider
     $prevToken = if ($tokens.Count -ge 2) { $tokens[-2].ToString() } else { "" }
     if ($prevToken -eq '--provider') {
-        @('claude', 'nessy', 'codex', 'qwen', 'cursor', 'windsurf', 'copilot', 'all') |
+        @('claude', 'nessy', 'gemini', 'codex', 'qwen', 'cursor', 'windsurf', 'copilot', 'all') |
         Where-Object { $_ -like "$wordToComplete*" } | ForEach-Object {
             [System.Management.Automation.CompletionResult]::new($_, $_, 'ParameterValue', $_)
         }
@@ -41,7 +41,7 @@ Register-ArgumentCompleter -Native -CommandName multiagent-setup -ScriptBlock {
         }
         'add-provider' {
             if ($tokens.Count -eq 1 -or ($tokens.Count -eq 2 -and $wordToComplete)) {
-                @('claude', 'nessy', 'codex', 'qwen', 'cursor', 'windsurf', 'copilot', 'all') | Where-Object { $_ -like "$wordToComplete*" } | ForEach-Object {
+                @('claude', 'nessy', 'gemini', 'codex', 'qwen', 'cursor', 'windsurf', 'copilot', 'all') | Where-Object { $_ -like "$wordToComplete*" } | ForEach-Object {
                     [System.Management.Automation.CompletionResult]::new($_, $_, 'ParameterValue', $_)
                 }
             } else {
@@ -51,7 +51,7 @@ Register-ArgumentCompleter -Native -CommandName multiagent-setup -ScriptBlock {
             }
         }
         'sync-roles' {
-            @('--clone', '--pull', '--agency-dir', '--workspace-root') | Where-Object { $_ -like "$wordToComplete*" } | ForEach-Object {
+            @('--clone', '--pull', '--agency-dir') | Where-Object { $_ -like "$wordToComplete*" } | ForEach-Object {
                 [System.Management.Automation.CompletionResult]::new($_, $_, 'ParameterName', $_)
             }
         }

--- a/tools/setup-cli/Templates/tools/completions.zsh
+++ b/tools/setup-cli/Templates/tools/completions.zsh
@@ -2,76 +2,24 @@
 # Source this file: source ./tools/completions.zsh
 # Or add to ~/.zshrc: source /path/to/project/tools/completions.zsh
 
-# --- multiagent-setup ---
-_multiagent_setup() {
-  local -a subcommands
-  subcommands=(
-    'new:Create a new multi-agent workspace'
-    'add-provider:Add a provider to an existing workspace'
-    'sync-roles:Sync agent roles to .claude/commands/'
-    'install-mcps:Install age-mcp and o-brien MCP servers'
-    'hook:Run a built-in hook (cross-platform)'
-  )
-
-  local -a providers
-  providers=(claude nessy gemini codex qwen all)
-
-  local -a hooks
-  hooks=(block-dangerous enforce-commit-msg auto-lint log-agent stop-guard research-reminder)
-
-  case $CURRENT in
-    2)
-      _describe 'subcommand' subcommands
-      ;;
-    *)
-      case ${words[2]} in
-        new|add-provider)
-          case $CURRENT in
-            3) _message 'project-name or provider' ;;
-            *) compadd -- --provider ${providers[@]} --force ;;
-          esac
-          ;;
-        sync-roles)
-          compadd -- --clone --pull --agency-dir --workspace-root
-          ;;
-        install-mcps)
-          compadd -- --docker --manual --age-conn --obrien-conn --target
-          ;;
-        hook)
-          compadd -- ${hooks[@]}
-          ;;
-      esac
-      ;;
-  esac
-}
-compdef _multiagent_setup multiagent-setup
-
 # --- /slash-commands via claude / nessy / gemini ---
 # Completes role names from ~/.claude/commands/ and .claude/commands/
 _ai_slash_commands() {
   local -a roles
-  local dir
-
-  # Global roles
   if [ -d "$HOME/.claude/commands" ]; then
     for f in "$HOME/.claude/commands"/*.md(N); do
       roles+=("/${${f:t}%.md}")
     done
   fi
-
-  # Project-level roles
   if [ -d ".claude/commands" ]; then
     for f in .claude/commands/*.md(N); do
       roles+=("/${${f:t}%.md}")
     done
   fi
-
-  # Deduplicate
   roles=(${(u)roles})
   _describe 'slash-command' roles
 }
 
-# Bind slash-command completion to supported agent CLIs
 for _agent_cmd in claude nessy gemini; do
   if (( $+commands[$_agent_cmd] )); then
     compdef _ai_slash_commands $_agent_cmd
@@ -84,12 +32,15 @@ _multiagent_setup() {
   local -a subcommands providers hooks
   subcommands=(
     'new:Create a new multi-agent workspace'
+    'add-provider:Add a provider to an existing workspace'
     'sync-roles:Sync agent roles to ~/.claude/commands/'
     'install-mcps:Install age-mcp and o-brien MCP servers'
-    'hook:Run a hook (cross-platform)'
+    'hook:Run a built-in hook (cross-platform)'
   )
   providers=(
     'claude:Claude Code by Anthropic (default)'
+    'nessy:Nessy CLI (Claude-compatible alias)'
+    'gemini:Google Gemini CLI'
     'codex:OpenAI Codex CLI'
     'qwen:Qwen Code by Alibaba'
     'cursor:Cursor IDE'
@@ -110,21 +61,18 @@ _multiagent_setup() {
           --provider) _describe 'provider' providers ;;
           *) _arguments '--provider[Provider to scaffold]:provider:->p' && _describe 'provider' providers ;;
         esac ;;
-      hook) _describe 'hook' hooks ;;
+      add-provider)
+        case $CURRENT in
+          3) _describe 'provider' providers ;;
+          *) compadd -- --force ;;
+        esac ;;
+      sync-roles)
+        compadd -- --clone --pull --agency-dir ;;
+      install-mcps)
+        compadd -- --docker --manual --age-conn --obrien-conn --target ;;
+      hook)
+        _describe 'hook' hooks ;;
     esac ;;
   esac
 }
 compdef _multiagent_setup multiagent-setup
-
-# --- orchestrator pipeline types ---
-_orchestrator_pipelines() {
-  local -a pipelines
-  pipelines=(
-    'feature:Full pipeline — PLAN→BUILD→TEST→VERIFY→SHIP'
-    'bugfix:Skip PLAN — BUILD→TEST→VERIFY→SHIP'
-    'infra:Skip TEST — PLAN→BUILD→VERIFY→SHIP'
-    'content:No SHIP — PLAN→BUILD→VERIFY(CEO)'
-    'spike:Research only — PLAN'
-  )
-  _describe 'pipeline' pipelines
-}


### PR DESCRIPTION
## Summary

### `add-provider` subcommand (new)
Adds a provider to an existing workspace without recreating it from scratch.

```bash
cd MyProject
multiagent-setup add-provider gemini      # adds Gemini config
multiagent-setup add-provider cursor      # adds Cursor rules
multiagent-setup add-provider codex       # adds Codex skills
multiagent-setup add-provider --force gemini  # overwrite existing
```

- Detects workspace root via `CLAUDE.md`
- Extracts only provider-specific templates (skips shared CLAUDE.md, docs/, etc.)
- Skips files that already exist unless `--force`

### Gemini CLI provider (new)
Scaffolds `.gemini/settings.json` and `GEMINI.md` for Google's [Gemini CLI](https://ai.google.dev/gemini-api/docs/gemini-cli).

```bash
multiagent-setup new MyProject --provider gemini
multiagent-setup new MyProject --provider all   # now includes gemini
```

### Bug fix: Program.cs / SyncRolesCommand mismatch
Fixed build-breaking call to `SyncRolesCommand` with 3 args when constructor takes 2.

### Completions updated
- `completions.zsh`: cleaned up duplicate function, added gemini/add-provider
- `completions.ps1`: added gemini, fixed sync-roles flags

## Test plan
- [ ] `multiagent-setup new MyProject --provider gemini` — verify `.gemini/` + `GEMINI.md` created
- [ ] `multiagent-setup add-provider cursor` from existing workspace — verify `.cursor/rules/` created
- [ ] `multiagent-setup add-provider nessy --force` — verify `.claude/` re-extracted
- [ ] `multiagent-setup -h` — verify add-provider in help text
- [ ] `multiagent-setup sync-roles --pull` — verify builds (no SyncRolesCommand 3-arg error)