### PR TITLE
feat: add QWEN.md context template for Qwen provider (v1.10.0)

### DIFF
--- a/tools/setup-cli/MultiagentSetup.csproj
+++ b/tools/setup-cli/MultiagentSetup.csproj
@@ -7,7 +7,7 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>multiagent-setup</ToolCommandName>
     <PackageId>multiagent-setup</PackageId>
-    <Version>1.9.0</Version>
+    <Version>1.10.0</Version>
     <Description>Scaffold a multi-agent AI workspace (Claude, Nessy, Gemini, Codex, Qwen, Cursor, Windsurf, Copilot)</Description>
     <Authors>Roman Melnikov</Authors>
     <PackageTags>claude;nessy;gemini;codex;qwen;cursor;windsurf;copilot;ai;multiagent;workspace;orchestrator;developer-tools;agents</PackageTags>
@@ -52,6 +52,7 @@
 
     <!-- Provider: Qwen -->
     <EmbeddedResource Include="Templates/providers/qwen/.qwen/settings.json" LogicalName="providers/qwen/.qwen/settings.json" />
+    <EmbeddedResource Include="Templates/providers/qwen/QWEN.md" LogicalName="providers/qwen/QWEN.md" />
 
     <!-- Provider: Cursor -->
     <EmbeddedResource Include="Templates/providers/cursor/.cursor/rules/workspace.mdc" LogicalName="providers/cursor/.cursor/rules/workspace.mdc" />

--- a/tools/setup-cli/Templates/providers/qwen/.qwen/settings.json
+++ b/tools/setup-cli/Templates/providers/qwen/.qwen/settings.json
@@ -1,3 +1,4 @@
 {
+  "contextFileName": "QWEN.md",
   "mcpServers": {}
 }

--- a/tools/setup-cli/Templates/providers/qwen/QWEN.md
+++ b/tools/setup-cli/Templates/providers/qwen/QWEN.md
@@ -1,0 +1,65 @@
+# {{PROJECT_NAME}} — Business Workspace
+
+{{PROJECT_DESCRIPTION}}
+
+**Founder:** {{FOUNDER}}. **Team:** AI agents. **Phase:** {{PHASE}}.
+
+---
+
+## How to start (required for every session)
+
+### 1. Determine mode
+
+| If the CEO... | Mode | What to do |
+|----------------|-------|------------|
+| Called `/orchestrator <task>` | **CEO Mode** | You = orchestrator. Read `docs/process.md`, then execute. |
+| Called `/<role> <question>` | **Single Expert** | You = that role. Answer as expert, no pipeline. |
+| Just asked a question | **Chief of Staff** | You = advisor. Help, suggest next step. |
+
+### 2. Load context
+
+**Always read:**
+- This file (already loaded)
+- `docs/process.md` — operational manual (if orchestrator mode)
+- `docs/role-capabilities.md` — capability index for role selection
+
+### 3. Act
+
+- **Orchestrator**: follow pipeline from `docs/process.md`.
+- **Single Expert**: answer within your role. No pipeline.
+- **Chief of Staff**: help CEO. Suggest `/orchestrator` for pipeline tasks.
+
+---
+
+## Workspace structure
+
+```
+~/{{PROJECT_NAME}}/
+├── code/
+│   └── {{PROJECT_NAME}}/   ← main code repo
+├── docs/
+│   ├── process.md           ← operational manual
+│   ├── role-capabilities.md ← capability index
+│   └── workflows/           ← pipeline specs
+└── .qwen/
+    ├── settings.json
+    └── commands/            ← role files (synced from agency-agents)
+```
+
+## Team (AI agents)
+
+**CEO** — {{FOUNDER}}. Sets direction, makes strategic decisions.
+
+**Orchestrator** — autonomous pipeline manager. Invoke via `/orchestrator <task>`.
+
+## Pipeline (summary)
+
+```
+PLAN → BUILD → TEST → VERIFY → SHIP
+```
+
+## Rules
+
+- **Confirm intent**: on ambiguous requests — clarify before acting.
+- **Don't overengineer**: simple solution > complex. Working first, pretty later.
+- **Git discipline**: `git status` before commit.


### PR DESCRIPTION
## Summary
- Add `QWEN.md` workspace context file for Qwen Code provider (parallel to `GEMINI.md`)
- Set `contextFileName: QWEN.md` in `.qwen/settings.json` so Qwen CLI picks it up
- Register `QWEN.md` as `EmbeddedResource` in `.csproj`
- Bump version to 1.10.0

## Why
`llms-full.txt` already documented `QWEN.md` as the Qwen context file, but the template was missing. Now `multiagent-setup new MyProject --provider qwen` (and `add-provider qwen`) will produce a `QWEN.md` at the workspace root with project-specific variables substituted.