### PR TITLE
docs: document add-provider subcommand in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ multiagent-setup new MyProject --provider windsurf   # Windsurf IDE
 multiagent-setup new MyProject --provider copilot    # GitHub Copilot
 multiagent-setup new MyProject --provider gemini     # Google Gemini CLI
 multiagent-setup new MyProject --provider all        # all providers at once
+
+# Add a provider to an existing workspace (no need to recreate)
+multiagent-setup add-provider cursor
+multiagent-setup add-provider gemini --force   # overwrite existing files
 ```
 
 Then start working:
@@ -187,6 +191,7 @@ See [`examples/`](examples/) for concrete workflows:
 
 ```bash
 multiagent-setup new <project> [org] [--provider claude|nessy|codex|qwen|cursor|windsurf|copilot|gemini|all]
+multiagent-setup add-provider <provider> [--force]   # add provider to existing workspace
 multiagent-setup sync-roles [--clone|--pull] [--agency-dir <path>]
 multiagent-setup install-mcps [--docker|--manual] [--age-conn <str>] [--obrien-conn <str>]
 multiagent-setup hook <name>


### PR DESCRIPTION
## Summary
- Add `add-provider` usage example to Quick Start code block
- Add `add-provider` to CLI Reference
- Closes the gap where a key v1.9.0 feature was invisible to README readers