### PR TITLE
feat: add add-provider example to landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -948,6 +948,16 @@
                     >multiagent-setup new MyProject --provider all</span
                   >
                 </div>
+                <div>&nbsp;</div>
+                <div>
+                  <span class="comment"
+                    ># Add a provider to an existing workspace</span
+                  >
+                </div>
+                <div>
+                  <span class="prompt">$ </span
+                  ><span class="cmd">multiagent-setup add-provider cursor</span>
+                </div>
               </div>
             </div>
           </div>


### PR DESCRIPTION
Shows `multiagent-setup add-provider cursor` in the Quick Start terminal section. The add-provider subcommand (v1.9.0) was missing from the landing page.