### PR TITLE
fix: correct add-provider CLI syntax in llms.txt/llms-full.txt

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -65,7 +65,7 @@ Syncs the latest agent role files from [agency-agents](https://github.com/msitar
 ### `add-provider` — Add provider to existing workspace
 
 ```bash
-multiagent-setup add-provider <provider> [--workspace-dir <path>] [--force]
+multiagent-setup add-provider <provider> [--force]
 ```
 
 Adds a new provider's scaffold (config files, hooks, role commands) to an existing workspace without rebuilding from scratch.

--- a/llms.txt
+++ b/llms.txt
@@ -60,7 +60,7 @@ All safety hooks are baked into the `multiagent-setup` binary (cross-platform, n
 
 ```
 multiagent-setup new <project> [org] [--provider <name>]
-multiagent-setup add-provider <provider> [--workspace-dir <path>] [--force]
+multiagent-setup add-provider <provider> [--force]
 multiagent-setup sync-roles [--clone|--pull] [--agency-dir <path>]
 multiagent-setup install-mcps [--docker|--manual]
 multiagent-setup hook <name>


### PR DESCRIPTION
Removes the non-existent `--workspace-dir` flag from `add-provider` usage in both LLM discovery files. The actual signature is `add-provider <provider> [--force]`.