### PR TITLE
docs: DX improvements to README + dev-advocate outreach materials

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,10 @@ Scaffold a multi-agent AI workspace where a team of specialized agents — orche
 
 ## Quick Start
 
+> **Recommended: one-liner bootstrap.** Installs all deps (git, gh, jq, .NET 10, agent CLI) and creates the workspace in one shot.
+
 ```bash
-# One-liner bootstrap (macOS / Linux — installs all deps + creates workspace)
+# macOS / Linux
 curl -fsSL https://raw.githubusercontent.com/Neftedollar/multiagent-template/main/bootstrap.sh | bash -s -- MyProject
 
 # Windows (PowerShell)
@@ -23,7 +25,7 @@ irm https://raw.githubusercontent.com/Neftedollar/multiagent-template/main/boots
 .\bootstrap.ps1 MyProject
 ```
 
-Already have git, gh, jq, and .NET 10 installed?
+Already have git, gh, jq, and .NET 10 installed? (You don't need to know .NET — it's just the packaging mechanism.)
 
 ```bash
 dotnet tool install -g multiagent-setup
@@ -74,16 +76,16 @@ Each step has an approval gate. Failures retry (3×) → helper role (2×) → h
 
 ## Supported Providers
 
-| Provider | Binary / Tool | Notes |
-|----------|---------------|-------|
-| **claude** | `claude` | [Claude Code](https://docs.anthropic.com/en/docs/claude-code) by Anthropic — default |
-| **nessy** | `nessy` | [Nessy CLI](https://nessy.ai) — Claude-compatible alias |
-| **codex** | `codex` | [OpenAI Codex CLI](https://github.com/openai/codex) |
-| **qwen** | `qwen-code` | [Qwen Code](https://github.com/QwenLM/qwen-code) by Alibaba |
-| **cursor** | [Cursor](https://cursor.com) IDE | Rules placed in `.cursor/rules/` (MDC format) |
-| **windsurf** | [Windsurf](https://windsurf.com) IDE | Rules placed in `.windsurf/rules/` (Wave 8+) |
-| **copilot** | GitHub Copilot | Reads `.github/copilot-instructions.md` |
-| **gemini** | `gemini` | [Gemini CLI](https://github.com/google-gemini/gemini-cli) by Google — creates `GEMINI.md` |
+| Provider | Binary / Tool | Best for | Notes |
+|----------|---------------|----------|-------|
+| **claude** | `claude` | Terminal-first, most capable | [Claude Code](https://docs.anthropic.com/en/docs/claude-code) by Anthropic — default |
+| **nessy** | `nessy` | Claude users with a different alias | [Nessy CLI](https://nessy.ai) — Claude-compatible |
+| **codex** | `codex` | OpenAI API key holders | [OpenAI Codex CLI](https://github.com/openai/codex) |
+| **qwen** | `qwen-code` | Open-source model users | [Qwen Code](https://github.com/QwenLM/qwen-code) by Alibaba |
+| **gemini** | `gemini` | Google API key holders | [Gemini CLI](https://github.com/google-gemini/gemini-cli) — creates `GEMINI.md` |
+| **cursor** | [Cursor](https://cursor.com) IDE | IDE-first workflows | Rules in `.cursor/rules/` (MDC format) |
+| **windsurf** | [Windsurf](https://windsurf.com) IDE | IDE-first + Codeium users | Rules in `.windsurf/rules/` (Wave 8+) |
+| **copilot** | GitHub Copilot | VS Code + GitHub users | Reads `.github/copilot-instructions.md` |
 
 Use `--provider all` to scaffold all providers (claude + nessy + codex + qwen + cursor + windsurf + copilot + gemini).
 
@@ -133,6 +135,15 @@ MyProject/
 └── tools/
     ├── completions.zsh      <- zsh completions
     └── completions.ps1      <- PowerShell completions
+```
+
+**Bringing in an existing codebase:**
+
+```bash
+multiagent-setup new MyProject
+cd MyProject
+git clone https://github.com/my-org/my-repo code/MyProject
+# Edit CLAUDE.md to describe the project → done
 ```
 
 ---

--- a/docs/marketing/article-devto.md
+++ b/docs/marketing/article-devto.md
@@ -1,0 +1,149 @@
+# I Built a Multi-Agent Dev Team in One Command — Here's What I Learned
+
+Most "agentic coding" tools are still just one model with a very long system prompt. You ask it to build a feature and it tries to be architect, developer, reviewer, and DevOps all at once. It context-collapses around step 3. The PR it opens would never survive a real code review.
+
+I spent several months building a different model: a structured workspace where specialized agents operate in a gated pipeline, each with a defined role and accountability boundary. The result is [multiagent-template](https://github.com/Neftedollar/multiagent-template) — a .NET 10 dotnet global tool that scaffolds the whole thing in one command.
+
+## The Core Idea: Role Separation + Gates
+
+The insight is simple: the reason a single AI agent struggles with a full feature is the same reason a single human junior dev would — no specialization, no review, no checks. The fix is also the same: a team with defined roles and handoffs.
+
+```
+PLAN → BUILD → TEST → VERIFY → SHIP
+```
+
+Each step is owned by a specialist role. The **Orchestrator** coordinates but never writes code. The **Architect** designs before the **Developer** builds. The **Reviewer** validates independently. Every step has a gate: `APPROVED` or `NEEDS WORK (reason)`. Failures retry 3×, then a helper role, then human escalation.
+
+You only get paged for things that actually need a human: public content decisions, breaking API changes, infra with cost impact, or 5+ consecutive failures.
+
+## Getting Started in 60 Seconds
+
+```bash
+# Full bootstrap on a clean machine (installs deps + scaffolds workspace)
+curl -fsSL https://raw.githubusercontent.com/Neftedollar/multiagent-template/main/bootstrap.sh | bash -s -- MyProject
+
+# Or, if you already have git, gh, jq, and .NET 10:
+dotnet tool install -g multiagent-setup
+multiagent-setup new MyProject --provider claude
+cd MyProject
+claude
+```
+
+Then give the orchestrator a task:
+
+```
+/orchestrator Implement user authentication with JWT
+```
+
+That's it. You'll get a PR.
+
+## What the Orchestrator Actually Does
+
+Here's what happens when you run that command against a Next.js + FastAPI project:
+
+1. `/product-manager` writes an EPIC with acceptance criteria
+2. `/engineering-software-architect` defines module boundaries and approach
+3. `/engineering-backend-architect` implements auth endpoints
+4. `/engineering-frontend-developer` builds the login/signup UI
+5. `/engineering-devops-automator` updates CI and secrets config
+6. `/engineering-code-reviewer` validates everything
+7. PR opened: `feat/auth-jwt`
+
+Your job: review and merge. Roughly 5 minutes of actual human time.
+
+The orchestrator picks roles dynamically from `docs/role-capabilities.md` — it doesn't hardcode assignments. If no standard role fits the task, it creates an ad-hoc role on the fly.
+
+## 8 Providers, One Tool
+
+The workspace isn't locked to Claude. The same pipeline structure scaffolds for:
+
+| Provider | How to use |
+|----------|-----------|
+| claude | `--provider claude` (default) |
+| OpenAI Codex | `--provider codex` |
+| Gemini CLI | `--provider gemini` |
+| Qwen Code | `--provider qwen` |
+| Cursor IDE | `--provider cursor` |
+| Windsurf IDE | `--provider windsurf` |
+| GitHub Copilot | `--provider copilot` |
+
+```bash
+# All providers at once
+multiagent-setup new MyProject --provider all
+
+# Add a provider to an existing workspace without recreating it
+multiagent-setup add-provider cursor
+```
+
+The rules and pipeline are placed in the right location for each provider (`.cursor/rules/`, `.windsurf/rules/`, `GEMINI.md`, etc.).
+
+## Safety Hooks Baked In
+
+Every workspace ships with hooks compiled into the binary — no shell scripts, no platform differences:
+
+- `block-dangerous` — blocks `rm -rf /`, `push --force main`, `DROP TABLE`, etc. at the PreToolUse level
+- `enforce-commit-msg` — enforces conventional commits before any `git commit` runs
+- `auto-lint` — runs the right formatter (prettier, ruff, gofmt, rustfmt) after every file edit
+- `log-agent` — logs every sub-agent launch to `.claude/agent-log.jsonl`
+- `stop-guard` — reminds agents to run tests before stopping
+
+These aren't suggestions written in markdown. They're enforced at the tool-call layer.
+
+## Autonomous Mode
+
+Once your backlog is populated in the GitHub Project, you can let the orchestrator run unsupervised:
+
+```bash
+# Add tasks to GitHub Project backlog, then:
+claude -p "/orchestrator"
+```
+
+The orchestrator picks the next task, runs the full pipeline, opens a PR, and moves to the next item. You check in when you want.
+
+This is the mode I use for routine maintenance tasks: dependency updates, documentation gaps, minor bug fixes. The agents handle the queue overnight; I review PRs in the morning.
+
+## What It Looks Like in Practice: Open Source Maintainer
+
+```bash
+multiagent-setup new MyLib my-github-org
+cd MyLib
+git clone https://github.com/my-github-org/my-library code/MyLib
+claude
+
+# Triage a week of issues at once:
+/orchestrator Review open PRs and triage new issues. Label by type, draft responses for issues needing clarification.
+
+# Prepare a release:
+/orchestrator Prepare release 2.2.0. Changes since 2.1.x: issues #38, #40, #42, #45. Update CHANGELOG, bump version, tag.
+```
+
+The `/engineering-technical-writer` handles CHANGELOG and migration guides. The `/engineering-devops-automator` bumps versions and tags. You merge.
+
+## What's Optional (but Powerful)
+
+Two infrastructure pieces are optional but change how agents retain context across sessions:
+
+**AGE Graph** — a knowledge base on PostgreSQL + Apache AGE. Stores modules, pipelines, role bindings, security findings. Grows with every task so the orchestrator doesn't re-discover your architecture on every session.
+
+**O'Brien** — semantic memory on pgvector. Cross-session context, task locking, crash recovery. Agents remember prior decisions.
+
+```bash
+multiagent-setup install-mcps   # interactive Docker setup
+```
+
+Neither is required to start. Both become useful once the project has real history.
+
+## The Design Principle I Keep Coming Back To
+
+The hardest part of building this wasn't the tooling — it was figuring out what the human should and shouldn't be involved in. The current answer:
+
+- **Agents decide**: implementation approach, file structure, test coverage, formatting, linting
+- **Human decides**: public-facing content, breaking changes, infra with cost impact, anything after 5+ failures
+
+Everything else runs without interruption. That boundary took a few iterations to get right, but it's what makes the autonomous mode actually usable rather than just a demo.
+
+---
+
+The project is MIT-licensed and installs as a standard dotnet global tool.
+
+If this is interesting to you, the repo is at [github.com/Neftedollar/multiagent-template](https://github.com/Neftedollar/multiagent-template). A star helps more developers find it — and if you try it, open an issue with what you find. The rough edges are real and I'm actively working through them.

--- a/docs/marketing/hn-launch-post.md
+++ b/docs/marketing/hn-launch-post.md
@@ -1,0 +1,21 @@
+# HN Launch Post
+
+**Title:** Show HN: multiagent-template – scaffold a gated multi-agent dev team in one command
+
+---
+
+**Post body:**
+
+I built a .NET dotnet global tool that scaffolds a structured multi-agent AI workspace: `dotnet tool install -g multiagent-setup && multiagent-setup new MyProject`.
+
+The problem I was trying to solve: single-agent coding tools collapse when given non-trivial tasks because they're forced to be architect, developer, reviewer, and DevOps simultaneously. The solution I landed on is explicit role separation with approval gates at each handoff — the same structure that makes human teams work. An Orchestrator coordinates and never writes code. Architects design before developers build. Reviewers validate independently. Each step either passes (`APPROVED`) or returns (`NEEDS WORK`) with a reason. After 3 retries a helper role is invoked; after 2 more the human is escalated. In practice, human escalation is rare.
+
+The scaffold supports 8 providers (Claude, OpenAI Codex, Gemini CLI, Qwen Code, Cursor, Windsurf, GitHub Copilot, Nessy) and places the right config in the right location for each one. Safety hooks — block-dangerous-commands, enforce-commit-msg, auto-lint, sub-agent logging — are compiled into the binary rather than shell scripts, so they work the same across platforms. There's also an optional infrastructure layer: an Apache AGE graph for persistent knowledge (module boundaries, role bindings, security findings) and a pgvector semantic memory store for cross-session context.
+
+The 20+ specialist roles come from the agency-agents project. The orchestrator routes dynamically via a capability index and creates ad-hoc roles when no standard role fits. In autonomous mode (`claude -p "/orchestrator"`), it pulls tasks from the GitHub Project backlog and runs the full pipeline without supervision, escalating only for defined edge cases.
+
+Repo: https://github.com/Neftedollar/multiagent-template
+NuGet: https://www.nuget.org/packages/multiagent-setup
+Landing: https://neftedollar.com/multiagent-template/
+
+Happy to discuss design decisions, particularly around the escalation policy and how the role routing works.

--- a/docs/marketing/outreach-plan.md
+++ b/docs/marketing/outreach-plan.md
@@ -1,0 +1,89 @@
+# Outreach Plan: DX Audit + Twitter/X Thread
+
+---
+
+## DX Audit — Top 5 Friction Points
+
+**1. .NET 10 as a prerequisite is a surprise**
+Most AI tool users don't have .NET installed. The README lists it in requirements but doesn't explain why the tool is built on it or how fast the install is.
+Fix: Add a one-liner to the Quick Start that installs .NET 10 inline, and add a note: "You don't need to know .NET — it's just the packaging mechanism."
+
+**2. The bootstrap URL is long but there's no "copy" hint**
+The curl one-liner is the fastest path but it's easy to mistype. There's no "recommended starting point" callout making it obvious this is the happy path.
+Fix: Add a visual callout (e.g. `> Recommended: use the bootstrap`) above the manual install steps.
+
+**3. No 5-minute outcome promise**
+The README explains what the tool does well, but a new visitor can't quickly answer "what will I have after 5 minutes?" without reading several sections.
+Fix: Add a "What you get in 5 minutes" summary block right after the Quick Start — one sentence each for workspace, pipeline, roles, and hooks.
+
+**4. The workspace structure diagram doesn't show a real project**
+The tree shows template placeholders (`MyProject/`). A visitor who already has a codebase needs to see one extra step: cloning their existing repo into `code/`.
+Fix: Add a second "existing project" code block after the workspace diagram showing `git clone <your-repo> code/MyProject/`.
+
+**5. Provider comparison table lacks a "best for" column**
+8 providers with no guidance on which to pick first is choice paralysis. A developer with Cursor already installed might not realize they can use that.
+Fix: Add a "Best for" column to the provider table (e.g. "terminal-first workflows", "IDE users", "OpenAI API key holders").
+
+---
+
+## Twitter/X Thread Outline
+
+**Tweet 1 (hook)**
+I got tired of AI coding tools that "help" by being architect, developer, and reviewer all at once and collapsing halfway through. So I built a structured alternative. Thread:
+
+**Tweet 2 (the problem)**
+Single-agent tools fail on real tasks because there's no role separation, no accountability, and no checkpoints. The context window fills up, the plan drifts, and the PR is a mess.
+
+**Tweet 3 (the solution)**
+multiagent-template scaffolds a pipeline with 20+ specialist roles and approval gates at every step:
+PLAN → BUILD → TEST → VERIFY → SHIP
+Each gate is APPROVED or NEEDS WORK (with a reason).
+
+**Tweet 4 (one command)**
+```bash
+dotnet tool install -g multiagent-setup
+multiagent-setup new MyProject --provider claude
+cd MyProject && claude
+/orchestrator Implement JWT auth
+```
+You'll have a PR in minutes. Your job: review and merge.
+
+**Tweet 5 (role separation)**
+The Orchestrator coordinates but never writes code. Architects design before developers build. Reviewers validate independently. Failures retry 3× → helper role → human escalation. You only get paged when it actually matters.
+
+**Tweet 6 (8 providers)**
+Not locked to one AI tool. Supports:
+- Claude, Codex, Gemini CLI, Qwen Code
+- Cursor, Windsurf, GitHub Copilot
+One command adds any provider to an existing workspace.
+
+**Tweet 7 (safety hooks)**
+Safety hooks compiled into the binary — not shell scripts:
+- block-dangerous: stops rm -rf /, force pushes, DROP TABLE
+- enforce-commit-msg: conventional commits only
+- auto-lint: prettier/ruff/gofmt after every edit
+No platform quirks.
+
+**Tweet 8 (autonomous mode)**
+Add tasks to your GitHub Project backlog, then:
+```bash
+claude -p "/orchestrator"
+```
+Agents run the full pipeline overnight. You review PRs in the morning. Human escalation is for edge cases only.
+
+**Tweet 9 (real use case)**
+Open source maintainer? One command triages a week of issues, drafts responses, bumps versions, writes CHANGELOG entries, and opens the release PR. You just merge.
+
+**Tweet 10 (optional infra)**
+Optional but powerful:
+- AGE graph (PostgreSQL + Apache AGE) — persistent knowledge of your codebase that grows with every task
+- O'Brien (pgvector) — cross-session memory, task locking, crash recovery
+
+**Tweet 11 (provenance)**
+20+ roles from the agency-agents project. The orchestrator routes dynamically via a capability index — no hardcoded assignments. Can create ad-hoc roles on the fly when nothing fits.
+
+**Tweet 12 (CTA)**
+MIT license. Installs as a standard dotnet global tool. Bootstrap script handles all deps on a clean machine.
+
+Repo: https://github.com/Neftedollar/multiagent-template
+If it's useful to you, a star helps other developers find it.


### PR DESCRIPTION
## Summary

### README improvements (from DX audit)
- Add `> Recommended:` bootstrap callout above manual install
- Add .NET clarification: "You don't need to know .NET — it's just the packaging mechanism"
- Add **Best for** column to provider table (removes choice paralysis for new users)
- Reorder provider table: terminal agents first, then IDE agents
- Add existing-project clone example in workspace section

### Marketing materials (for Roman to use when ready to launch)
- `docs/marketing/article-devto.md` — full dev.to/Hashnode article (800-1200 words), ready to publish
- `docs/marketing/hn-launch-post.md` — Show HN post (no hype, technical)
- `docs/marketing/outreach-plan.md` — DX audit top 5 + Twitter/X thread outline (12 tweets)