### PR TITLE
feat: add AGENTS.md context template for Codex provider (v1.11.0)

### DIFF
--- a/tools/setup-cli/MultiagentSetup.csproj
+++ b/tools/setup-cli/MultiagentSetup.csproj
@@ -7,7 +7,7 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>multiagent-setup</ToolCommandName>
     <PackageId>multiagent-setup</PackageId>
-    <Version>1.10.0</Version>
+    <Version>1.11.0</Version>
     <Description>Scaffold a multi-agent AI workspace (Claude, Nessy, Gemini, Codex, Qwen, Cursor, Windsurf, Copilot)</Description>
     <Authors>Roman Melnikov</Authors>
     <PackageTags>claude;nessy;gemini;codex;qwen;cursor;windsurf;copilot;ai;multiagent;workspace;orchestrator;developer-tools;agents</PackageTags>
@@ -49,6 +49,7 @@
     <EmbeddedResource Include="Templates/providers/codex/.codex/config.toml" LogicalName="providers/codex/.codex/config.toml" />
     <EmbeddedResource Include="Templates/providers/codex/.codex/hooks.json" LogicalName="providers/codex/.codex/hooks.json" />
     <EmbeddedResource Include="Templates/providers/codex/.codex/skills/orchestrator.md" LogicalName="providers/codex/.codex/skills/orchestrator.md" />
+    <EmbeddedResource Include="Templates/providers/codex/AGENTS.md" LogicalName="providers/codex/AGENTS.md" />
 
     <!-- Provider: Qwen -->
     <EmbeddedResource Include="Templates/providers/qwen/.qwen/settings.json" LogicalName="providers/qwen/.qwen/settings.json" />

--- a/tools/setup-cli/Templates/providers/codex/AGENTS.md
+++ b/tools/setup-cli/Templates/providers/codex/AGENTS.md
@@ -1,0 +1,66 @@
+# {{PROJECT_NAME}} — Business Workspace
+
+{{PROJECT_DESCRIPTION}}
+
+**Founder:** {{FOUNDER}}. **Team:** AI agents. **Phase:** {{PHASE}}.
+
+---
+
+## How to start (required for every session)
+
+### 1. Determine mode
+
+| If the CEO... | Mode | What to do |
+|----------------|-------|------------|
+| Called `/orchestrator <task>` | **CEO Mode** | You = orchestrator. Read `docs/process.md`, then execute. |
+| Called `/<role> <question>` | **Single Expert** | You = that role. Answer as expert, no pipeline. |
+| Just asked a question | **Chief of Staff** | You = advisor. Help, suggest next step. |
+
+### 2. Load context
+
+**Always read:**
+- This file (already loaded)
+- `docs/process.md` — operational manual (if orchestrator mode)
+- `docs/role-capabilities.md` — capability index for role selection
+
+### 3. Act
+
+- **Orchestrator**: follow pipeline from `docs/process.md`.
+- **Single Expert**: answer within your role. No pipeline.
+- **Chief of Staff**: help CEO. Suggest `/orchestrator` for pipeline tasks.
+
+---
+
+## Workspace structure
+
+```
+~/{{PROJECT_NAME}}/
+├── code/
+│   └── {{PROJECT_NAME}}/   ← main code repo
+├── docs/
+│   ├── process.md           ← operational manual
+│   ├── role-capabilities.md ← capability index
+│   └── workflows/           ← pipeline specs
+└── .codex/
+    ├── config.toml
+    ├── hooks.json           ← hooks wired to multiagent-setup binary
+    └── skills/              ← orchestrator skill pre-loaded
+```
+
+## Team (AI agents)
+
+**CEO** — {{FOUNDER}}. Sets direction, makes strategic decisions.
+
+**Orchestrator** — autonomous pipeline manager. Invoke via `/orchestrator <task>`.
+
+## Pipeline (summary)
+
+```
+PLAN → BUILD → TEST → VERIFY → SHIP
+```
+
+## Rules
+
+- **Confirm intent**: on ambiguous requests — clarify before acting.
+- **Don't overengineer**: simple solution > complex. Working first, pretty later.
+- **Git discipline**: `git status` before commit.


### PR DESCRIPTION
## Summary
- Add `AGENTS.md` workspace context file for OpenAI Codex CLI provider (placed at workspace root)
- Parallel to `CLAUDE.md`, `GEMINI.md`, `QWEN.md`
- Already documented in `llms-full.txt` as the Codex context file — now the template actually exists
- Bump to v1.11.0