### PR TITLE
docs: add 'What you get in 5 minutes' summary to Quick Start

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,12 @@ claude          # or: nessy / codex / qwen-code / gemini (terminal agents)
 /orchestrator Implement user authentication with JWT
 ```
 
+**What you get in 5 minutes:**
+- A workspace where agents run `PLAN → BUILD → TEST → VERIFY → SHIP` autonomously
+- 20+ specialist roles installed in `~/.claude/commands/` — orchestrator, architect, developer, reviewer, DevOps, designer, and more
+- Safety hooks active: dangerous commands blocked, commits enforced as conventional, files auto-linted on save
+- One human touchpoint: review and merge the PR when the pipeline finishes
+
 ---
 
 ## Why multiagent-template?


### PR DESCRIPTION
Adds a clear 4-bullet summary right after the Quick Start commands, answering 'what will I have after 5 minutes?' without the user having to read further.