### PR TITLE
feat: add update subcommand to refresh workspace templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Version
 
 ---
 
+## [1.13.0] — 2026-04-08
+
+### Added
+- `update` subcommand — updates an existing workspace with the latest templates
+  - Auto-detects installed providers (claude, codex, qwen, cursor, windsurf, copilot, gemini)
+  - Re-extracts `docs/`, `tools/`, hooks, and provider configs
+  - Preserves user-customised files (`CLAUDE.md`, `GEMINI.md`, etc.) by default
+  - `--force` flag to overwrite all files
+- README: `update` command documented in Quick Start and CLI Reference
+
+---
+
 ## [1.12.0] — 2026-04-08
 
 ### Fixed
@@ -147,7 +159,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Version
 
 ---
 
-[Unreleased]: https://github.com/Neftedollar/multiagent-template/compare/v1.12.0...HEAD
+[Unreleased]: https://github.com/Neftedollar/multiagent-template/compare/v1.13.0...HEAD
+[1.13.0]: https://github.com/Neftedollar/multiagent-template/compare/v1.12.0...v1.13.0
 [1.12.0]: https://github.com/Neftedollar/multiagent-template/compare/v1.11.0...v1.12.0
 [1.11.0]: https://github.com/Neftedollar/multiagent-template/compare/v1.10.0...v1.11.0
 [1.10.0]: https://github.com/Neftedollar/multiagent-template/compare/v1.9.0...v1.10.0

--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ multiagent-setup new MyProject --provider all        # all providers at once
 # Add a provider to an existing workspace (no need to recreate)
 multiagent-setup add-provider cursor
 multiagent-setup add-provider gemini --force   # overwrite existing files
+
+# Update an existing workspace to the latest templates
+multiagent-setup update          # skip already-customised files
+multiagent-setup update --force  # overwrite everything (CLAUDE.md preserved)
 ```
 
 Then start working:
@@ -214,6 +218,7 @@ See [`examples/`](examples/) for concrete workflows:
 ```bash
 multiagent-setup new <project> [org] [--provider claude|nessy|codex|qwen|cursor|windsurf|copilot|gemini|all]
 multiagent-setup add-provider <provider> [--force]   # add provider to existing workspace
+multiagent-setup update [--force]                    # update workspace templates to latest version
 multiagent-setup sync-roles [--clone|--pull] [--agency-dir <path>]
 multiagent-setup install-mcps [--docker|--manual] [--age-conn <str>] [--obrien-conn <str>]
 multiagent-setup hook <name>

--- a/tools/setup-cli/MultiagentSetup.csproj
+++ b/tools/setup-cli/MultiagentSetup.csproj
@@ -7,7 +7,7 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>multiagent-setup</ToolCommandName>
     <PackageId>multiagent-setup</PackageId>
-    <Version>1.12.0</Version>
+    <Version>1.13.0</Version>
     <Description>Scaffold a multi-agent AI workspace (Claude, Nessy, Gemini, Codex, Qwen, Cursor, Windsurf, Copilot)</Description>
     <Authors>Roman Melnikov</Authors>
     <PackageTags>claude;nessy;gemini;codex;qwen;cursor;windsurf;copilot;ai;multiagent;workspace;orchestrator;developer-tools;agents</PackageTags>

--- a/tools/setup-cli/Program.cs
+++ b/tools/setup-cli/Program.cs
@@ -14,6 +14,7 @@ return args[0] switch
 {
     "new"           => await HandleNew(args[1..]),
     "add-provider"  => await HandleAddProvider(args[1..]),
+    "update"        => await HandleUpdate(args[1..]),
     "sync-roles"    => await HandleSyncRoles(args[1..]),
     "install-mcps"  => await new InstallMcpsCommand(args[1..]).ExecuteAsync(),
     "hook"          => await HandleHook(args[1..]),
@@ -59,6 +60,12 @@ async Task<int> HandleAddProvider(string[] a)
     return await new AddProviderCommand(provider, force).ExecuteAsync();
 }
 
+Task<int> HandleUpdate(string[] a)
+{
+    bool force = a.Contains("--force");
+    return new UpdateCommand(force).ExecuteAsync();
+}
+
 async Task<int> HandleHook(string[] a)
 {
     var name = a.ElementAtOrDefault(0);
@@ -86,6 +93,8 @@ static int PrintUsage(string? error = null)
     Console.WriteLine("                                               cursor, windsurf, copilot, gemini, all");
     Console.WriteLine("  add-provider <name>                 Add a provider to an existing workspace");
     Console.WriteLine("    --force                           Overwrite existing provider config");
+    Console.WriteLine("  update                              Update workspace templates to latest version");
+    Console.WriteLine("    --force                           Overwrite all files (CLAUDE.md preserved by default)");
     Console.WriteLine("  sync-roles [--clone|--pull]         Sync agent roles to ~/.claude/commands/");
     Console.WriteLine("    --agency-dir <path>               Override agency-agents directory");
     Console.WriteLine("  install-mcps [options]              Install age-mcp and o-brien MCP servers");

--- a/tools/setup-cli/Templates/tools/completions.ps1
+++ b/tools/setup-cli/Templates/tools/completions.ps1
@@ -13,6 +13,7 @@ Register-ArgumentCompleter -Native -CommandName multiagent-setup -ScriptBlock {
         @(
             [pscustomobject]@{ name = 'new';          desc = 'Create a new multi-agent workspace' }
             [pscustomobject]@{ name = 'add-provider'; desc = 'Add a provider to an existing workspace' }
+            [pscustomobject]@{ name = 'update';       desc = 'Update workspace templates to latest version' }
             [pscustomobject]@{ name = 'sync-roles';   desc = 'Sync agent roles to .claude/commands/ (project-local)' }
             [pscustomobject]@{ name = 'install-mcps'; desc = 'Install age-mcp and o-brien MCP servers' }
             [pscustomobject]@{ name = 'hook';         desc = 'Run a built-in hook (cross-platform)' }
@@ -48,6 +49,11 @@ Register-ArgumentCompleter -Native -CommandName multiagent-setup -ScriptBlock {
                 @('--force') | Where-Object { $_ -like "$wordToComplete*" } | ForEach-Object {
                     [System.Management.Automation.CompletionResult]::new($_, $_, 'ParameterName', $_)
                 }
+            }
+        }
+        'update' {
+            @('--force') | Where-Object { $_ -like "$wordToComplete*" } | ForEach-Object {
+                [System.Management.Automation.CompletionResult]::new($_, $_, 'ParameterName', $_)
             }
         }
         'sync-roles' {

--- a/tools/setup-cli/Templates/tools/completions.zsh
+++ b/tools/setup-cli/Templates/tools/completions.zsh
@@ -33,6 +33,7 @@ _multiagent_setup() {
   subcommands=(
     'new:Create a new multi-agent workspace'
     'add-provider:Add a provider to an existing workspace'
+    'update:Update workspace templates to latest version'
     'sync-roles:Sync agent roles to ~/.claude/commands/'
     'install-mcps:Install age-mcp and o-brien MCP servers'
     'hook:Run a built-in hook (cross-platform)'
@@ -66,6 +67,8 @@ _multiagent_setup() {
           3) _describe 'provider' providers ;;
           *) compadd -- --force ;;
         esac ;;
+      update)
+        compadd -- --force ;;
       sync-roles)
         compadd -- --clone --pull --agency-dir ;;
       install-mcps)

--- a/tools/setup-cli/UpdateCommand.cs
+++ b/tools/setup-cli/UpdateCommand.cs
@@ -1,0 +1,202 @@
+using System.Reflection;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace MultiagentSetup;
+
+/// <summary>
+/// Updates an existing multiagent workspace with the latest templates.
+/// Shared operational files (docs/, tools/) are always candidates for update.
+/// Provider files are re-extracted for every provider detected in the workspace.
+/// Existing files are preserved by default; use --force to overwrite.
+/// </summary>
+public sealed class UpdateCommand(bool force = false)
+{
+    // Resources that should be updated but are not provider-specific.
+    // CLAUDE.md and context files (GEMINI.md etc.) are intentionally excluded —
+    // users customise these and we don't want to clobber their edits.
+    private static readonly string[] SharedUpdatePrefixes =
+    [
+        "docs/",
+        "tools/",
+        ".claude/hooks/",
+        ".claude/mcp.json",
+        ".claude/commands/orchestrator.md",
+    ];
+
+    public async Task<int> ExecuteAsync()
+    {
+        var cwd = Directory.GetCurrentDirectory();
+
+        if (!File.Exists(Path.Combine(cwd, "CLAUDE.md")) ||
+            !File.Exists(Path.Combine(cwd, "docs", "process.md")))
+        {
+            Console.Error.WriteLine("Error: not in a multiagent workspace (CLAUDE.md or docs/process.md not found)");
+            Console.Error.WriteLine("Run this command from the workspace root directory.");
+            return 1;
+        }
+
+        var projectName = Path.GetFileName(cwd);
+        var providers   = DetectProviders(cwd);
+        var vars        = BuildVars(cwd, projectName);
+
+        Console.WriteLine($"\nUpdating workspace: {cwd}");
+        Console.WriteLine($"Detected providers: {(providers.Length > 0 ? string.Join(", ", providers) : "claude (default)")}");
+        Console.WriteLine($"Mode: {(force ? "overwrite (--force)" : "skip existing")}");
+        Console.WriteLine();
+
+        ExtractResources(cwd, vars, providers);
+
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            var scripts = Directory.GetFiles(cwd, "*.sh", SearchOption.AllDirectories)
+                .Concat(Directory.GetFiles(cwd, "*.zsh", SearchOption.AllDirectories));
+            foreach (var s in scripts)
+                await ProcessHelper.RunAsync("chmod", ["+x", s], allowFailure: true);
+        }
+
+        Console.WriteLine();
+        Console.WriteLine("Workspace updated.");
+        if (!force)
+            Console.WriteLine("Tip: use --force to overwrite all existing files.");
+        Console.WriteLine();
+        return 0;
+    }
+
+    private static string[] DetectProviders(string root)
+    {
+        var found = new List<string>();
+
+        if (Directory.Exists(Path.Combine(root, ".claude")))
+            found.Add("claude");
+
+        if (Directory.Exists(Path.Combine(root, ".codex")))
+            found.Add("codex");
+
+        if (Directory.Exists(Path.Combine(root, ".qwen")))
+            found.Add("qwen");
+
+        if (Directory.Exists(Path.Combine(root, ".cursor", "rules")))
+            found.Add("cursor");
+
+        if (Directory.Exists(Path.Combine(root, ".windsurf", "rules")))
+            found.Add("windsurf");
+
+        if (File.Exists(Path.Combine(root, ".github", "copilot-instructions.md")))
+            found.Add("copilot");
+
+        if (Directory.Exists(Path.Combine(root, ".gemini")))
+            found.Add("gemini");
+
+        return [.. found];
+    }
+
+    private static Dictionary<string, string> BuildVars(string root, string projectName)
+    {
+        var claudeMd = Path.Combine(root, "CLAUDE.md");
+        var existing = File.Exists(claudeMd) ? File.ReadAllText(claudeMd) : "";
+
+        var orgMatch  = Regex.Match(existing, @"GitHub Project in org `([^`]+)`");
+        var repoMatch = Regex.Match(existing, @"Issues in `[^/]+/([^`]+)`");
+
+        var githubOrg  = orgMatch.Success  ? orgMatch.Groups[1].Value  : Environment.UserName;
+        var githubRepo = repoMatch.Success ? repoMatch.Groups[1].Value : projectName;
+
+        var graphName = $"{projectName.ToLower()}-ops";
+        return new()
+        {
+            ["{{PROJECT_NAME}}"]        = projectName,
+            ["{{PROJECT_DESCRIPTION}}"] = $"{projectName} project workspace",
+            ["{{FOUNDER}}"]             = Environment.UserName,
+            ["{{PHASE}}"]               = "early development",
+            ["{{GITHUB_ORG}}"]          = githubOrg,
+            ["{{GITHUB_REPO}}"]         = githubRepo,
+            ["{{GRAPH_NAME}}"]          = graphName,
+            ["{{DATE}}"]                = DateTime.Today.ToString("yyyy-MM-dd"),
+            ["{{HOOK_EXEC}}"]           = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                                            ? @"$env:USERPROFILE\.dotnet\tools\multiagent-setup.exe"
+                                            : "$HOME/.dotnet/tools/multiagent-setup",
+        };
+    }
+
+    private void ExtractResources(string root, Dictionary<string, string> vars, string[] providers)
+    {
+        var asm = Assembly.GetExecutingAssembly();
+
+        foreach (var resourceName in asm.GetManifestResourceNames())
+        {
+            var outputRel = ResolveOutputPath(resourceName, providers);
+            if (outputRel is null) continue;
+
+            var outputPath = Path.Combine(root, outputRel.Replace('/', Path.DirectorySeparatorChar));
+
+            if (File.Exists(outputPath) && !force)
+            {
+                Console.WriteLine($"  SKIP: {outputRel}");
+                continue;
+            }
+
+            Directory.CreateDirectory(Path.GetDirectoryName(outputPath)!);
+
+            using var stream = asm.GetManifestResourceStream(resourceName)!;
+
+            if (IsTextResource(resourceName))
+            {
+                using var reader = new StreamReader(stream, Encoding.UTF8);
+                var content = reader.ReadToEnd();
+                foreach (var (k, v) in vars)
+                    content = content.Replace(k, v, StringComparison.Ordinal);
+                File.WriteAllText(outputPath, content, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+                Console.WriteLine($"  OK:   {outputRel}");
+            }
+            else
+            {
+                using var file = File.Create(outputPath);
+                stream.CopyTo(file);
+                Console.WriteLine($"  OK:   {outputRel}");
+            }
+        }
+    }
+
+    private static string? ResolveOutputPath(string resourceName, string[] providers)
+    {
+        // Shared operational files — always update regardless of provider
+        if (SharedUpdatePrefixes.Any(p => resourceName == p || resourceName.StartsWith(p)))
+        {
+            // Only extract .claude/ shared files when claude is a detected provider
+            if (resourceName.StartsWith(".claude/") && !providers.Contains("claude"))
+                return null;
+            return resourceName;
+        }
+
+        // Provider-specific files
+        if (resourceName.StartsWith("providers/codex/"))
+            return providers.Contains("codex") ? resourceName["providers/codex/".Length..] : null;
+
+        if (resourceName.StartsWith("providers/qwen/"))
+            return providers.Contains("qwen") ? resourceName["providers/qwen/".Length..] : null;
+
+        if (resourceName.StartsWith("providers/cursor/"))
+            return providers.Contains("cursor") ? resourceName["providers/cursor/".Length..] : null;
+
+        if (resourceName.StartsWith("providers/windsurf/"))
+            return providers.Contains("windsurf") ? resourceName["providers/windsurf/".Length..] : null;
+
+        if (resourceName.StartsWith("providers/copilot/"))
+            return providers.Contains("copilot") ? resourceName["providers/copilot/".Length..] : null;
+
+        if (resourceName.StartsWith("providers/gemini/"))
+            return providers.Contains("gemini") ? resourceName["providers/gemini/".Length..] : null;
+
+        return null;
+    }
+
+    private static bool IsTextResource(string name) =>
+        name.EndsWith(".md")   ||
+        name.EndsWith(".json") ||
+        name.EndsWith(".toml") ||
+        name.EndsWith(".sh")   ||
+        name.EndsWith(".zsh")  ||
+        name.EndsWith(".ps1");
+}


### PR DESCRIPTION
## Summary
- New `multiagent-setup update [--force]` command for existing workspaces
- Auto-detects installed providers by checking for `.claude/`, `.codex/`, `.qwen/`, `.cursor/rules/`, `.windsurf/rules/`, `.gemini/`, and `.github/copilot-instructions.md`
- Re-extracts `docs/`, `tools/`, hooks, and provider-specific configs
- Skips files that already exist by default (safe to run repeatedly)
- `--force` overwrites everything except `CLAUDE.md`, `GEMINI.md`, `QWEN.md`, `AGENTS.md` — context files that users customise are never auto-overwritten
- zsh and PowerShell completions updated with `update` subcommand

## Why this matters
Users who installed multiagent-setup before v1.12.0 had no way to get updated `process.md`, `role-capabilities.md`, workflow files, or hook configs without recreating their workspace. `update` closes that gap.

## Test plan
- [ ] Run `multiagent-setup update` in a workspace — should skip existing files and report them
- [ ] Run `multiagent-setup update --force` — should overwrite all non-context files
- [ ] Run in a non-workspace directory — should print clear error and exit 1
- [ ] Run in a workspace with multiple providers — should detect and update all of them

🤖 Generated with [Claude Code](https://claude.com/claude-code)