### PR TITLE
feat: add --provider flag to bootstrap.sh and bootstrap.ps1

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,12 @@ Scaffold a multi-agent AI workspace where a team of specialized agents — orche
 ```bash
 # macOS / Linux
 curl -fsSL https://raw.githubusercontent.com/Neftedollar/multiagent-template/main/bootstrap.sh | bash -s -- MyProject
+curl -fsSL https://raw.githubusercontent.com/Neftedollar/multiagent-template/main/bootstrap.sh | bash -s -- MyProject --provider gemini
 
 # Windows (PowerShell)
 irm https://raw.githubusercontent.com/Neftedollar/multiagent-template/main/bootstrap.ps1 -OutFile bootstrap.ps1
 .\bootstrap.ps1 MyProject
+.\bootstrap.ps1 MyProject --provider codex
 ```
 
 Already have git, gh, jq, and .NET 10 installed? (You don't need to know .NET — it's just the packaging mechanism.)

--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -2,12 +2,14 @@
 # Installs all dependencies and creates the workspace in one command.
 #
 # Usage:
-#   irm https://raw.githubusercontent.com/Neftedollar/multiagent-template/main/bootstrap.ps1 | iex
-#   # or locally:
-#   .\bootstrap.ps1 MyProject [github-org]
+#   irm https://raw.githubusercontent.com/Neftedollar/multiagent-template/main/bootstrap.ps1 -OutFile bootstrap.ps1
+#   .\bootstrap.ps1 MyProject
+#   .\bootstrap.ps1 MyProject --provider gemini
+#   .\bootstrap.ps1 MyProject my-org --provider all
 param(
     [Parameter(Position=0, Mandatory=$true)][string]$ProjectName,
-    [Parameter(Position=1)][string]$GithubOrg = ""
+    [Parameter(Position=1)][string]$GithubOrg = "",
+    [string]$Provider = ""
 )
 
 $ErrorActionPreference = "Stop"
@@ -27,8 +29,9 @@ function Install-WinGet([string]$Id, [string]$Name) {
 
 Write-Host "============================================"
 Write-Host "  Multi-Agent Workspace Bootstrap"
-Write-Host "  Project: $ProjectName"
-Write-Host "  OS: Windows"
+Write-Host "  Project:  $ProjectName"
+Write-Host "  Provider: $(if ($Provider) { $Provider } else { 'claude (default)' })"
+Write-Host "  OS:       Windows"
 Write-Host "============================================"
 Write-Host ""
 
@@ -109,8 +112,9 @@ if (-not $installed) {
     & dotnet tool update -g multiagent-setup 2>&1 | Out-Null
 }
 
-$argList = @($ProjectName)
-if ($GithubOrg) { $argList += $GithubOrg }
+$argList = @("new", $ProjectName)
+if ($GithubOrg)  { $argList += $GithubOrg }
+if ($Provider)   { $argList += "--provider"; $argList += $Provider }
 
 & multiagent-setup @argList
 exit $LASTEXITCODE

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -4,21 +4,35 @@
 #
 # Usage:
 #   curl -fsSL https://raw.githubusercontent.com/Neftedollar/multiagent-template/main/bootstrap.sh | bash -s -- MyProject
+#   bash -s -- MyProject --provider gemini
+#   bash -s -- MyProject my-org --provider all
 #   # or locally:
-#   ./bootstrap.sh MyProject [github-org]
+#   ./bootstrap.sh MyProject [github-org] [--provider <name>]
 
 set -euo pipefail
 
-PROJECT_NAME="${1:?Usage: ./bootstrap.sh <project-name> [github-org]}"
-GITHUB_ORG="${2:-}"
+PROJECT_NAME="${1:?Usage: ./bootstrap.sh <project-name> [github-org] [--provider <name>]}"
+shift
+GITHUB_ORG=""
+PROVIDER=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --provider) PROVIDER="$2"; shift 2 ;;
+    --provider=*) PROVIDER="${1#*=}"; shift ;;
+    -*) shift ;;
+    *) GITHUB_ORG="$1"; shift ;;
+  esac
+done
 
 OS="$(uname -s)"
 has() { command -v "$1" &>/dev/null; }
 
 echo "============================================"
 echo "  Multi-Agent Workspace Bootstrap"
-echo "  Project: $PROJECT_NAME"
-echo "  OS: $OS $(uname -m)"
+echo "  Project:  $PROJECT_NAME"
+echo "  Provider: ${PROVIDER:-claude (default)}"
+echo "  OS:       $OS $(uname -m)"
 echo "============================================"
 echo ""
 
@@ -108,8 +122,7 @@ if ! dotnet tool list -g 2>/dev/null | grep -q '^multiagent-setup\b'; then
   dotnet tool install -g multiagent-setup
 fi
 
-if [ -n "$GITHUB_ORG" ]; then
-  multiagent-setup "$PROJECT_NAME" "$GITHUB_ORG"
-else
-  multiagent-setup "$PROJECT_NAME"
-fi
+SETUP_ARGS=("new" "$PROJECT_NAME")
+[ -n "$GITHUB_ORG" ] && SETUP_ARGS+=("$GITHUB_ORG")
+[ -n "$PROVIDER" ]   && SETUP_ARGS+=("--provider" "$PROVIDER")
+multiagent-setup "${SETUP_ARGS[@]}"


### PR DESCRIPTION
Users can now pick their AI provider in the one-liner bootstrap:

```bash
curl -fsSL .../bootstrap.sh | bash -s -- MyProject --provider gemini
curl -fsSL .../bootstrap.sh | bash -s -- MyProject --provider codex
.\bootstrap.ps1 MyProject --provider all
```

Previously the bootstrap always created a Claude workspace. Now it passes `--provider` through to `multiagent-setup new`. The header also shows which provider was selected.

README updated to show the `--provider` example in the Quick Start bootstrap block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)