### PR TITLE
feat: add-provider all — add every provider in one command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Version
 
 ---
 
+## [1.14.0] — 2026-04-09
+
+### Added
+- `add-provider all` — adds all providers to an existing workspace in one command
+- README: `add-provider all` example in Quick Start
+- bootstrap.sh + bootstrap.ps1: `--provider` flag support
+
+---
+
 ## [1.13.0] — 2026-04-08
 
 ### Added
@@ -159,7 +168,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Version
 
 ---
 
-[Unreleased]: https://github.com/Neftedollar/multiagent-template/compare/v1.13.0...HEAD
+[Unreleased]: https://github.com/Neftedollar/multiagent-template/compare/v1.14.0...HEAD
+[1.14.0]: https://github.com/Neftedollar/multiagent-template/compare/v1.13.0...v1.14.0
 [1.13.0]: https://github.com/Neftedollar/multiagent-template/compare/v1.12.0...v1.13.0
 [1.12.0]: https://github.com/Neftedollar/multiagent-template/compare/v1.11.0...v1.12.0
 [1.11.0]: https://github.com/Neftedollar/multiagent-template/compare/v1.10.0...v1.11.0

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ multiagent-setup new MyProject --provider all        # all providers at once
 # Add a provider to an existing workspace (no need to recreate)
 multiagent-setup add-provider cursor
 multiagent-setup add-provider gemini --force   # overwrite existing files
+multiagent-setup add-provider all              # add all providers at once
 
 # Update an existing workspace to the latest templates
 multiagent-setup update          # skip already-customised files

--- a/tools/setup-cli/MultiagentSetup.csproj
+++ b/tools/setup-cli/MultiagentSetup.csproj
@@ -7,7 +7,7 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>multiagent-setup</ToolCommandName>
     <PackageId>multiagent-setup</PackageId>
-    <Version>1.13.0</Version>
+    <Version>1.14.0</Version>
     <Description>Scaffold a multi-agent AI workspace (Claude, Nessy, Gemini, Codex, Qwen, Cursor, Windsurf, Copilot)</Description>
     <Authors>Roman Melnikov</Authors>
     <PackageTags>claude;nessy;gemini;codex;qwen;cursor;windsurf;copilot;ai;multiagent;workspace;orchestrator;developer-tools;agents</PackageTags>

--- a/tools/setup-cli/Program.cs
+++ b/tools/setup-cli/Program.cs
@@ -54,8 +54,19 @@ async Task<int> HandleAddProvider(string[] a)
     bool force = a.Contains("--force");
 
     string[] validProviders = ["nessy", "codex", "qwen", "cursor", "windsurf", "copilot", "gemini"];
+
+    if (provider == "all")
+    {
+        foreach (var p in validProviders)
+        {
+            var r = await new AddProviderCommand(p, force).ExecuteAsync();
+            if (r != 0) return r;
+        }
+        return 0;
+    }
+
     if (!validProviders.Contains(provider))
-        return PrintUsage(error: $"Unknown provider '{provider}'. Valid: nessy, codex, qwen, cursor, windsurf, copilot, gemini");
+        return PrintUsage(error: $"Unknown provider '{provider}'. Valid: nessy, codex, qwen, cursor, windsurf, copilot, gemini, all");
 
     return await new AddProviderCommand(provider, force).ExecuteAsync();
 }
@@ -92,6 +103,7 @@ static int PrintUsage(string? error = null)
     Console.WriteLine("    --provider <name>                 Provider: claude (default), nessy, codex, qwen,");
     Console.WriteLine("                                               cursor, windsurf, copilot, gemini, all");
     Console.WriteLine("  add-provider <name>                 Add a provider to an existing workspace");
+    Console.WriteLine("    <name>: nessy, codex, qwen, cursor, windsurf, copilot, gemini, all");
     Console.WriteLine("    --force                           Overwrite existing provider config");
     Console.WriteLine("  update                              Update workspace templates to latest version");
     Console.WriteLine("    --force                           Overwrite all files (CLAUDE.md preserved by default)");


### PR DESCRIPTION
Implements `multiagent-setup add-provider all` which iterates over all 7 providers (nessy, codex, qwen, cursor, windsurf, copilot, gemini) and adds each to the existing workspace.

Previously this was mentioned in README_RU but silently failed with "Unknown provider 'all'". Now it works.

Also bundles the bootstrap `--provider` changes and CHANGELOG update for v1.14.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)