### PR TITLE
fix: replace Environment.Exit in install-mcps with return codes, mask passwords

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Version
 
 ---
 
+## [1.15.0] — 2026-04-09
+
+### Fixed
+- `install-mcps`: replaced `Environment.Exit(0)` inside `SetupDockerAsync` with proper `return false` — callers now receive a result instead of the process aborting mid-execution, making the method composable and testable
+- `install-mcps`: connection strings are now masked in console output (`password=***`)
+
+---
+
 ## [1.14.0] — 2026-04-09
 
 ### Added
@@ -168,7 +176,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Version
 
 ---
 
-[Unreleased]: https://github.com/Neftedollar/multiagent-template/compare/v1.14.0...HEAD
+[Unreleased]: https://github.com/Neftedollar/multiagent-template/compare/v1.15.0...HEAD
+[1.15.0]: https://github.com/Neftedollar/multiagent-template/compare/v1.14.0...v1.15.0
 [1.14.0]: https://github.com/Neftedollar/multiagent-template/compare/v1.13.0...v1.14.0
 [1.13.0]: https://github.com/Neftedollar/multiagent-template/compare/v1.12.0...v1.13.0
 [1.12.0]: https://github.com/Neftedollar/multiagent-template/compare/v1.11.0...v1.12.0

--- a/tools/setup-cli/InstallMcpsCommand.cs
+++ b/tools/setup-cli/InstallMcpsCommand.cs
@@ -67,7 +67,9 @@ public sealed class InstallMcpsCommand
                 Environment.SetEnvironmentVariable("PATH", path + sep + dotnetTools);
         }
 
-        var (ageConn, obrienDbUrl) = await ResolveConnectionStringsAsync();
+        var connResult = await ResolveConnectionStringsAsync();
+        if (connResult is null) return 0;
+        var (ageConn, obrienDbUrl) = connResult.Value;
 
         var errors = await InstallDotnetToolsAsync();
         if (errors > 0) return 1;
@@ -79,8 +81,8 @@ public sealed class InstallMcpsCommand
         Console.WriteLine("  my-mcps installed!");
         Console.WriteLine("================================");
         Console.WriteLine();
-        Console.WriteLine($"  age-mcp connection: {ageConn}");
-        Console.WriteLine($"  o-brien connection: {obrienDbUrl}");
+        Console.WriteLine($"  age-mcp connection: {MaskConnString(ageConn)}");
+        Console.WriteLine($"  o-brien connection: {MaskConnString(obrienDbUrl)}");
         Console.WriteLine();
         Console.WriteLine("  Start a Claude Code session — both MCPs are ready.");
         Console.WriteLine();
@@ -89,7 +91,7 @@ public sealed class InstallMcpsCommand
 
     // ── Connection strings ────────────────────────────────────────────────────
 
-    private async Task<(string ageConn, string obrienDbUrl)> ResolveConnectionStringsAsync()
+    private async Task<(string ageConn, string obrienDbUrl)?> ResolveConnectionStringsAsync()
     {
         if (_ageConnArg is not null && _obrienConnArg is not null)
             return (_ageConnArg, _obrienConnArg);
@@ -122,7 +124,7 @@ public sealed class InstallMcpsCommand
             return (age, obrien);
         }
 
-        await SetupDockerAsync();
+        if (!await SetupDockerAsync()) return null;
         return (AgeConnDocker, ObrienDbUrlDocker);
     }
 
@@ -136,9 +138,17 @@ public sealed class InstallMcpsCommand
         return string.IsNullOrEmpty(input) ? defaultValue : input;
     }
 
+    // Mask passwords in connection strings for safe console output
+    private static string MaskConnString(string conn)
+    {
+        // Replace password=... or Password=... values
+        return System.Text.RegularExpressions.Regex.Replace(
+            conn, @"(?i)(password=)[^;@]+", "$1***");
+    }
+
     // ── Docker ────────────────────────────────────────────────────────────────
 
-    private async Task SetupDockerAsync()
+    private async Task<bool> SetupDockerAsync()
     {
         var agemcpDir = Path.Combine(_targetDir, "age-mcp");
 
@@ -162,7 +172,7 @@ public sealed class InstallMcpsCommand
             {
                 Console.Error.WriteLine("FAIL: install Docker Desktop — https://docker.com/products/docker-desktop");
             }
-            Environment.Exit(0);
+            return false;
         }
 
         var (infoCode, _, _) = await ProcessHelper.RunAsync("docker", ["info"],
@@ -173,7 +183,7 @@ public sealed class InstallMcpsCommand
             if (OperatingSystem.IsMacOS())
                 await ProcessHelper.RunAsync("open", ["-a", "Docker"], allowFailure: true);
             Console.WriteLine("  >>  Wait for Docker Desktop to start, then re-run.");
-            Environment.Exit(0);
+            return false;
         }
         Console.WriteLine("  OK: docker");
 
@@ -263,6 +273,8 @@ public sealed class InstallMcpsCommand
                 ? $"  OK: o-brien database running on :{ObrienPort}"
                 : $"  WARN: o-brien postgres not reachable on :{ObrienPort} yet");
         }
+
+        return true;
     }
 
     // ── dotnet tools ─────────────────────────────────────────────────────────

--- a/tools/setup-cli/MultiagentSetup.csproj
+++ b/tools/setup-cli/MultiagentSetup.csproj
@@ -7,7 +7,7 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>multiagent-setup</ToolCommandName>
     <PackageId>multiagent-setup</PackageId>
-    <Version>1.14.0</Version>
+    <Version>1.15.0</Version>
     <Description>Scaffold a multi-agent AI workspace (Claude, Nessy, Gemini, Codex, Qwen, Cursor, Windsurf, Copilot)</Description>
     <Authors>Roman Melnikov</Authors>
     <PackageTags>claude;nessy;gemini;codex;qwen;cursor;windsurf;copilot;ai;multiagent;workspace;orchestrator;developer-tools;agents</PackageTags>


### PR DESCRIPTION
## Summary

- `SetupDockerAsync` now returns `Task<bool>` instead of calling `Environment.Exit(0)` — callers receive a clean result rather than the process aborting mid-execution
- Connection strings are masked in console output (`password=***`) via new `MaskConnString` helper
- Bumps to v1.15.0

## Changes

- `InstallMcpsCommand.cs`: `SetupDockerAsync` → `Task<bool>`, two `Environment.Exit(0)` → `return false`, `return true` at end; `ResolveConnectionStringsAsync` → nullable tuple; `ExecuteAsync` checks null result; `MaskConnString` added; output uses masked strings
- `MultiagentSetup.csproj`: 1.14.0 → 1.15.0
- `CHANGELOG.md`: v1.15.0 entry

## Test plan

- [ ] `multiagent-setup install-mcps --docker` on a machine without Docker — should print install instructions and exit 0 without stack trace
- [ ] `multiagent-setup install-mcps --docker` with Docker not running — should print "Wait for Docker Desktop" and exit 0
- [ ] `multiagent-setup install-mcps --manual --age-conn "...Password=secret..." --obrien-conn "...Password=secret..."` — passwords should appear as `***` in output