### PR TITLE
refactor: extract IsTextResource to shared helper, fix missing .mdc in update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Version
 
 ---
 
+## [1.15.1] — 2026-04-09
+
+### Fixed
+- `update`: Cursor `.mdc` files were being written as binary — `IsTextResource` was missing `.mdc` extension in `UpdateCommand`
+
+### Changed
+- `IsTextResource` extracted to shared `TemplateResources` helper — removes duplication across `SetupCommand`, `AddProviderCommand`, `UpdateCommand`
+
+---
+
 ## [1.15.0] — 2026-04-09
 
 ### Fixed
@@ -176,7 +186,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Version
 
 ---
 
-[Unreleased]: https://github.com/Neftedollar/multiagent-template/compare/v1.15.0...HEAD
+[Unreleased]: https://github.com/Neftedollar/multiagent-template/compare/v1.15.1...HEAD
+[1.15.1]: https://github.com/Neftedollar/multiagent-template/compare/v1.15.0...v1.15.1
 [1.15.0]: https://github.com/Neftedollar/multiagent-template/compare/v1.14.0...v1.15.0
 [1.14.0]: https://github.com/Neftedollar/multiagent-template/compare/v1.13.0...v1.14.0
 [1.13.0]: https://github.com/Neftedollar/multiagent-template/compare/v1.12.0...v1.13.0

--- a/tools/setup-cli/AddProviderCommand.cs
+++ b/tools/setup-cli/AddProviderCommand.cs
@@ -139,7 +139,7 @@ public sealed class AddProviderCommand(string provider, bool force = false)
 
             using var stream = asm.GetManifestResourceStream(resourceName)!;
 
-            if (IsTextResource(resourceName))
+            if (TemplateResources.IsTextResource(resourceName))
             {
                 using var reader = new StreamReader(stream, Encoding.UTF8);
                 var content = reader.ReadToEnd();
@@ -183,12 +183,4 @@ public sealed class AddProviderCommand(string provider, bool force = false)
         return null;
     }
 
-    private static bool IsTextResource(string name) =>
-        name.EndsWith(".md")   ||
-        name.EndsWith(".json") ||
-        name.EndsWith(".toml") ||
-        name.EndsWith(".sh")   ||
-        name.EndsWith(".zsh")  ||
-        name.EndsWith(".ps1")  ||
-        name.EndsWith(".mdc");
 }

--- a/tools/setup-cli/MultiagentSetup.csproj
+++ b/tools/setup-cli/MultiagentSetup.csproj
@@ -7,7 +7,7 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>multiagent-setup</ToolCommandName>
     <PackageId>multiagent-setup</PackageId>
-    <Version>1.15.0</Version>
+    <Version>1.15.1</Version>
     <Description>Scaffold a multi-agent AI workspace (Claude, Nessy, Gemini, Codex, Qwen, Cursor, Windsurf, Copilot)</Description>
     <Authors>Roman Melnikov</Authors>
     <PackageTags>claude;nessy;gemini;codex;qwen;cursor;windsurf;copilot;ai;multiagent;workspace;orchestrator;developer-tools;agents</PackageTags>

--- a/tools/setup-cli/SetupCommand.cs
+++ b/tools/setup-cli/SetupCommand.cs
@@ -221,7 +221,7 @@ public sealed class SetupCommand(string projectName, string? requestedOrg, strin
 
             using var stream = asm.GetManifestResourceStream(resourceName)!;
 
-            if (IsTextResource(resourceName))
+            if (TemplateResources.IsTextResource(resourceName))
             {
                 using var reader = new StreamReader(stream, Encoding.UTF8);
                 var content = reader.ReadToEnd();
@@ -264,14 +264,6 @@ public sealed class SetupCommand(string projectName, string? requestedOrg, strin
         return resourceName;
     }
 
-    private static bool IsTextResource(string name) =>
-        name.EndsWith(".md")   ||
-        name.EndsWith(".mdc")  ||
-        name.EndsWith(".json") ||
-        name.EndsWith(".toml") ||
-        name.EndsWith(".sh")   ||
-        name.EndsWith(".zsh")  ||
-        name.EndsWith(".ps1");
 
     // ── Permissions ───────────────────────────────────────────────────────────
 

--- a/tools/setup-cli/TemplateResources.cs
+++ b/tools/setup-cli/TemplateResources.cs
@@ -1,0 +1,13 @@
+namespace MultiagentSetup;
+
+internal static class TemplateResources
+{
+    internal static bool IsTextResource(string name) =>
+        name.EndsWith(".md")   ||
+        name.EndsWith(".mdc")  ||
+        name.EndsWith(".json") ||
+        name.EndsWith(".toml") ||
+        name.EndsWith(".sh")   ||
+        name.EndsWith(".zsh")  ||
+        name.EndsWith(".ps1");
+}

--- a/tools/setup-cli/UpdateCommand.cs
+++ b/tools/setup-cli/UpdateCommand.cs
@@ -141,7 +141,7 @@ public sealed class UpdateCommand(bool force = false)
 
             using var stream = asm.GetManifestResourceStream(resourceName)!;
 
-            if (IsTextResource(resourceName))
+            if (TemplateResources.IsTextResource(resourceName))
             {
                 using var reader = new StreamReader(stream, Encoding.UTF8);
                 var content = reader.ReadToEnd();
@@ -192,11 +192,4 @@ public sealed class UpdateCommand(bool force = false)
         return null;
     }
 
-    private static bool IsTextResource(string name) =>
-        name.EndsWith(".md")   ||
-        name.EndsWith(".json") ||
-        name.EndsWith(".toml") ||
-        name.EndsWith(".sh")   ||
-        name.EndsWith(".zsh")  ||
-        name.EndsWith(".ps1");
 }


### PR DESCRIPTION
## Summary

- Extracted identical `IsTextResource` from three files into `TemplateResources.cs`
- Fixed a real bug: `UpdateCommand.IsTextResource` was missing `.mdc` — Cursor template files were being written as binary during `update`, corrupting them
- Bumps to v1.15.1

## Changes

- New `tools/setup-cli/TemplateResources.cs` with canonical `IsTextResource` (all 7 extensions incl. `.mdc`)
- `SetupCommand`, `AddProviderCommand`, `UpdateCommand`: removed private duplicates, call `TemplateResources.IsTextResource`
- `CHANGELOG.md`: v1.15.1 entry