### PR TITLE
chore: gitignore agency-agents, hook, my-mcps, scheduled_tasks.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,8 @@ code/
 .DS_Store
 .claude/settings.local.json
 .claude/agent-log.jsonl
+.claude/scheduled_tasks.lock
 tools/agency-agents/
+agency-agents/
+hook/
+my-mcps/


### PR DESCRIPTION
Prevents local dev artifacts from showing in git status. No functional changes.