### PR TITLE
fix: tighten force-push hook pattern to avoid false positives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Version
 
 ---
 
+## [1.15.3] — 2026-04-09
+
+### Fixed
+- `block-dangerous` hook: tightened force-push patterns to avoid false positives when PR body or commit message text contains "git push --force main" as documentation or test-plan text; patterns now require `--force`/`-f` and `main`/`master` to be adjacent git arguments
+
+---
+
 ## [1.15.2] — 2026-04-09
 
 ### Added
@@ -194,7 +201,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Version
 
 ---
 
-[Unreleased]: https://github.com/Neftedollar/multiagent-template/compare/v1.15.2...HEAD
+[Unreleased]: https://github.com/Neftedollar/multiagent-template/compare/v1.15.3...HEAD
+[1.15.3]: https://github.com/Neftedollar/multiagent-template/compare/v1.15.2...v1.15.3
 [1.15.2]: https://github.com/Neftedollar/multiagent-template/compare/v1.15.1...v1.15.2
 [1.15.1]: https://github.com/Neftedollar/multiagent-template/compare/v1.15.0...v1.15.1
 [1.15.0]: https://github.com/Neftedollar/multiagent-template/compare/v1.14.0...v1.15.0

--- a/tools/setup-cli/HooksCommand.cs
+++ b/tools/setup-cli/HooksCommand.cs
@@ -28,9 +28,9 @@ public sealed class HooksCommand(string hookName)
         (new(@"rm\s+-rf\s+/",                                RegexOptions.IgnoreCase), "rm -rf /"),
         (new(@"rm\s+-rf\s+\.",                               RegexOptions.IgnoreCase), "rm -rf ."),
         (new(@"rm\s+-rf\s+\*",                               RegexOptions.IgnoreCase), "rm -rf *"),
-        (new(@"git\s+push\s+.*--force.*\s+(main|master)",    RegexOptions.IgnoreCase), "force push to main/master"),
-        (new(@"git\s+push\s+-f\s+.*\s+(main|master)",        RegexOptions.IgnoreCase), "force push to main/master"),
-        (new(@"git\s+push\s+(--force|-f)\s*$",               RegexOptions.IgnoreCase), "force push (no branch specified — affects tracked branch)"),
+        // Match: git push [--force|-f] [origin] main|master   or   git push origin [--force|-f] main|master
+        (new(@"git\s+push\s+(?:(?:--force|-f)\s+(?:origin\s+)?|origin\s+(?:--force|-f)\s+)(main|master)(?:\s|$)", RegexOptions.IgnoreCase), "force push to main/master"),
+        (new(@"git\s+push\s+(--force|-f)\s*(?:2>|$)",        RegexOptions.IgnoreCase), "force push (no branch specified — affects tracked branch)"),
         (new(@"git\s+reset\s+--hard\s+origin/(main|master)", RegexOptions.IgnoreCase), "git reset --hard origin/main"),
         (new(@"git\s+clean\s+-fd",                           RegexOptions.IgnoreCase), "git clean -fd"),
         (new(@"DROP\s+(TABLE|DATABASE)",                     RegexOptions.IgnoreCase), "DROP TABLE/DATABASE"),

--- a/tools/setup-cli/MultiagentSetup.csproj
+++ b/tools/setup-cli/MultiagentSetup.csproj
@@ -7,7 +7,7 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>multiagent-setup</ToolCommandName>
     <PackageId>multiagent-setup</PackageId>
-    <Version>1.15.2</Version>
+    <Version>1.15.3</Version>
     <Description>Scaffold a multi-agent AI workspace (Claude, Nessy, Gemini, Codex, Qwen, Cursor, Windsurf, Copilot)</Description>
     <Authors>Roman Melnikov</Authors>
     <PackageTags>claude;nessy;gemini;codex;qwen;cursor;windsurf;copilot;ai;multiagent;workspace;orchestrator;developer-tools;agents</PackageTags>


### PR DESCRIPTION
The force-push patterns now require the branch name to appear as a direct git argument adjacent to the force flag, preventing false positives when PR body text or commit messages mention these patterns as documentation.