### PR TITLE
feat: add doctor command for workspace health validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Version
 
 ---
 
+## [1.16.0] — 2026-04-09
+
+### Added
+- `doctor` command — workspace health checker: validates required files (`CLAUDE.md`, `docs/process.md`, `role-capabilities.md`, `.claude/`), agent roles, hook configuration, required tools (`git`, `gh`, `dotnet`), and at least one AI agent CLI on PATH; exits 0 on warnings-only, 1 on errors
+- `doctor` added to shell completions (zsh + PowerShell)
+
+### Fixed
+- `sync-roles`: default action changed from empty string to `--pull` (was silently a no-op)
+
+---
+
 ## [1.15.3] — 2026-04-09
 
 ### Fixed

--- a/tools/setup-cli/DoctorCommand.cs
+++ b/tools/setup-cli/DoctorCommand.cs
@@ -1,0 +1,125 @@
+namespace MultiagentSetup;
+
+public sealed class DoctorCommand
+{
+    public async Task<int> ExecuteAsync()
+    {
+        var cwd  = Directory.GetCurrentDirectory();
+        var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+
+        Console.WriteLine("multiagent-setup doctor");
+        Console.WriteLine("=======================");
+        Console.WriteLine();
+
+        int errors = 0, warnings = 0;
+
+        // ── Workspace files ───────────────────────────────────────────────────
+        Console.WriteLine("Workspace files:");
+        errors   += Check(File.Exists(Path.Combine(cwd, "CLAUDE.md")),       "  CLAUDE.md", required: true);
+        errors   += Check(File.Exists(Path.Combine(cwd, "docs", "process.md")), "  docs/process.md", required: true);
+        warnings += Check(File.Exists(Path.Combine(cwd, "docs", "role-capabilities.md")), "  docs/role-capabilities.md", required: false);
+        warnings += Check(Directory.Exists(Path.Combine(cwd, ".claude")),    "  .claude/ directory", required: false);
+        Console.WriteLine();
+
+        // ── Agent roles ───────────────────────────────────────────────────────
+        Console.WriteLine("Agent roles:");
+        var globalCommands = Path.Combine(home, ".claude", "commands");
+        var projectCommands = Path.Combine(cwd, ".claude", "commands");
+        var globalCount  = Directory.Exists(globalCommands)  ? Directory.GetFiles(globalCommands,  "*.md").Length : 0;
+        var projectCount = Directory.Exists(projectCommands) ? Directory.GetFiles(projectCommands, "*.md").Length : 0;
+        Console.WriteLine(globalCount > 0
+            ? $"  OK   ~/.claude/commands/ — {globalCount} roles"
+            : "  WARN ~/.claude/commands/ — no roles (run: multiagent-setup sync-roles --clone)");
+        if (globalCount == 0) warnings++;
+        if (projectCount > 0) Console.WriteLine($"  OK   .claude/commands/ — {projectCount} project-level roles");
+        Console.WriteLine();
+
+        // ── Hook configuration ────────────────────────────────────────────────
+        Console.WriteLine("Hook configuration:");
+        var settingsPath = Path.Combine(cwd, ".claude", "settings.json");
+        if (!File.Exists(settingsPath))
+        {
+            Console.WriteLine("  WARN .claude/settings.json — not found (hooks disabled)");
+            warnings++;
+        }
+        else
+        {
+            Console.WriteLine("  OK   .claude/settings.json");
+            var settingsContent = await File.ReadAllTextAsync(settingsPath);
+            if (settingsContent.Contains("{{HOOK_EXEC}}"))
+            {
+                Console.WriteLine("  WARN .claude/settings.json — contains unresolved {{HOOK_EXEC}} (recreate workspace)");
+                warnings++;
+            }
+        }
+        Console.WriteLine();
+
+        // ── Required CLI tools ────────────────────────────────────────────────
+        Console.WriteLine("Required tools:");
+        errors   += Check(ProcessHelper.IsOnPath("git"),  "  git");
+        warnings += Check(ProcessHelper.IsOnPath("gh"),   "  gh (GitHub CLI)", required: false);
+        warnings += Check(ProcessHelper.IsOnPath("dotnet"), "  dotnet", required: false);
+        Console.WriteLine();
+
+        // ── Agent CLI (at least one required) ────────────────────────────────
+        Console.WriteLine("Agent CLIs (need at least one):");
+        string[] agents = ["claude", "nessy", "codex", "qwen-code", "gemini"];
+        var foundAgents = agents.Where(ProcessHelper.IsOnPath).ToArray();
+        bool hasIdeProviders = Directory.Exists(Path.Combine(cwd, ".cursor", "rules"))
+            || Directory.Exists(Path.Combine(cwd, ".windsurf", "rules"))
+            || File.Exists(Path.Combine(cwd, ".github", "copilot-instructions.md"));
+
+        if (foundAgents.Length == 0 && !hasIdeProviders)
+        {
+            Console.WriteLine("  WARN no agent CLI found — install claude, codex, qwen-code, or gemini");
+            warnings++;
+        }
+        foreach (var a in foundAgents)
+            Console.WriteLine($"  OK   {a}");
+        if (hasIdeProviders)
+            Console.WriteLine("  OK   IDE provider (cursor/windsurf/copilot) detected");
+        Console.WriteLine();
+
+        // ── Optional infrastructure ───────────────────────────────────────────
+        Console.WriteLine("Optional infrastructure:");
+        var mcpPath = Path.Combine(cwd, ".claude", "mcp.json");
+        if (File.Exists(mcpPath))
+        {
+            var mcp = await File.ReadAllTextAsync(mcpPath);
+            Console.WriteLine(mcp.Contains("age-mcp")    ? "  OK   age-mcp configured"    : "  --   age-mcp not configured");
+            Console.WriteLine(mcp.Contains("o-brien")    ? "  OK   o-brien configured"     : "  --   o-brien not configured");
+        }
+        else
+        {
+            Console.WriteLine("  --   no .claude/mcp.json (run: multiagent-setup install-mcps)");
+        }
+        Console.WriteLine();
+
+        // ── Summary ───────────────────────────────────────────────────────────
+        if (errors == 0 && warnings == 0)
+        {
+            Console.WriteLine("All checks passed. Workspace is healthy.");
+        }
+        else
+        {
+            if (errors > 0)
+                Console.WriteLine($"{errors} error(s) — workspace may not function correctly.");
+            if (warnings > 0)
+                Console.WriteLine($"{warnings} warning(s) — workspace may have reduced functionality.");
+        }
+        Console.WriteLine();
+        return errors > 0 ? 1 : 0;
+    }
+
+    private static int Check(bool condition, string label, bool required = true)
+    {
+        if (condition)
+        {
+            Console.WriteLine($"  OK   {label.TrimStart()}");
+            return 0;
+        }
+        var prefix = required ? "  FAIL" : "  WARN";
+        Console.WriteLine($"{prefix} {label.TrimStart()}");
+        return 1;
+    }
+}

--- a/tools/setup-cli/MultiagentSetup.csproj
+++ b/tools/setup-cli/MultiagentSetup.csproj
@@ -7,7 +7,7 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>multiagent-setup</ToolCommandName>
     <PackageId>multiagent-setup</PackageId>
-    <Version>1.15.3</Version>
+    <Version>1.16.0</Version>
     <Description>Scaffold a multi-agent AI workspace (Claude, Nessy, Gemini, Codex, Qwen, Cursor, Windsurf, Copilot)</Description>
     <Authors>Roman Melnikov</Authors>
     <PackageTags>claude;nessy;gemini;codex;qwen;cursor;windsurf;copilot;ai;multiagent;workspace;orchestrator;developer-tools;agents</PackageTags>

--- a/tools/setup-cli/Program.cs
+++ b/tools/setup-cli/Program.cs
@@ -18,6 +18,7 @@ return args[0] switch
     "sync-roles"    => await HandleSyncRoles(args[1..]),
     "install-mcps"  => await new InstallMcpsCommand(args[1..]).ExecuteAsync(),
     "hook"          => await HandleHook(args[1..]),
+    "doctor"        => await new DoctorCommand().ExecuteAsync(),
     _ when !args[0].StartsWith('-') => await HandleNew(args), // backward compat
     _ => PrintUsage(error: $"Unknown command: {args[0]}")
 };
@@ -86,7 +87,7 @@ async Task<int> HandleHook(string[] a)
 
 async Task<int> HandleSyncRoles(string[] a)
 {
-    var action = a.FirstOrDefault(x => x is "--clone" or "--pull") ?? "";
+    var action = a.FirstOrDefault(x => x is "--clone" or "--pull") ?? "--pull";
     string? agDir = null;
     for (int i = 0; i < a.Length - 1; i++)
         if (a[i] == "--agency-dir") agDir = a[i + 1];
@@ -117,6 +118,7 @@ static int PrintUsage(string? error = null)
     Console.WriteLine("    --target <dir>                    Target dir for age-mcp clone");
     Console.WriteLine("  hook <name>                         Run a hook (cross-platform)");
     Console.WriteLine("    block-dangerous | enforce-commit-msg | auto-lint | log-agent | stop-guard");
+    Console.WriteLine("  doctor                              Check workspace health (tools, files, hooks)");
     Console.WriteLine();
     Console.WriteLine("Options:");
     Console.WriteLine("  -h, --help                          Show this help");

--- a/tools/setup-cli/Templates/tools/completions.ps1
+++ b/tools/setup-cli/Templates/tools/completions.ps1
@@ -17,6 +17,7 @@ Register-ArgumentCompleter -Native -CommandName multiagent-setup -ScriptBlock {
             [pscustomobject]@{ name = 'sync-roles';   desc = 'Sync agent roles to .claude/commands/ (project-local)' }
             [pscustomobject]@{ name = 'install-mcps'; desc = 'Install age-mcp and o-brien MCP servers' }
             [pscustomobject]@{ name = 'hook';         desc = 'Run a built-in hook (cross-platform)' }
+            [pscustomobject]@{ name = 'doctor';       desc = 'Check workspace health — tools, files, hooks, roles' }
         ) | Where-Object { $_.name -like "$wordToComplete*" } | ForEach-Object {
             [System.Management.Automation.CompletionResult]::new($_.name, $_.name, 'ParameterValue', $_.desc)
         }

--- a/tools/setup-cli/Templates/tools/completions.zsh
+++ b/tools/setup-cli/Templates/tools/completions.zsh
@@ -37,6 +37,7 @@ _multiagent_setup() {
     'sync-roles:Sync agent roles to ~/.claude/commands/'
     'install-mcps:Install age-mcp and o-brien MCP servers'
     'hook:Run a built-in hook (cross-platform)'
+    'doctor:Check workspace health — tools, files, hooks, roles'
   )
   providers=(
     'claude:Claude Code by Anthropic (default)'
@@ -75,6 +76,7 @@ _multiagent_setup() {
         compadd -- --docker --manual --age-conn --obrien-conn --target ;;
       hook)
         _describe 'hook' hooks ;;
+      doctor) ;; # no args
     esac ;;
   esac
 }


### PR DESCRIPTION
## Summary

- Adds `doctor` command — validates workspace health: required files, agent roles, hook config, required tools (`git`, `gh`, `dotnet`), and at least one AI agent CLI on PATH
- Fixes `sync-roles` silent no-op: default action was empty string, now correctly defaults to `--pull`
- Shell completions updated (zsh + PowerShell) for `doctor`
- Bumps to v1.16.0

## Test plan

- [ ] `multiagent-setup doctor` in a fresh workspace — should show green checks
- [ ] `multiagent-setup doctor` missing CLAUDE.md — should error with clear message
- [ ] `multiagent-setup sync-roles` (no flags) — should default to `--pull` behavior
- [ ] Tab-complete `multiagent-setup doctor` in zsh and PowerShell