### PR TITLE
feat: add Cline and Aider providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Version
 
 ---
 
+## [1.17.0] — 2026-04-09
+
+### Added
+- **Cline provider** (`--provider cline` / `add-provider cline`) — generates `.clinerules` for VS Code Cline and Roo Code extensions; rules load automatically per project
+- **Aider provider** (`--provider aider` / `add-provider aider`) — generates `.aider.conf.yml` (auto-reads `CLAUDE.md` + `docs/process.md`) and `AIDER.md`; includes conventional-commit prompt
+- Both providers included in `--provider all`
+- `TemplateResources.IsTextResource` extended with `.yml`, `.yaml`, and `.clinerules` support
+- Shell completions (zsh + PowerShell) updated for new providers
+
+---
+
 ## [1.16.0] — 2026-04-09
 
 ### Added

--- a/tools/setup-cli/AddProviderCommand.cs
+++ b/tools/setup-cli/AddProviderCommand.cs
@@ -62,6 +62,10 @@ public sealed class AddProviderCommand(string provider, bool force = false)
             Console.WriteLine($"  copilot       → open {cwd} in VS Code, reads .github/copilot-instructions.md");
         else if (provider is "gemini")
             Console.WriteLine($"  gemini        → /orchestrator <task>");
+        else if (provider is "cline")
+            Console.WriteLine($"  cline         → open {cwd} in VS Code with Cline extension, .clinerules loads automatically");
+        else if (provider is "aider")
+            Console.WriteLine($"  aider         → run 'aider' from {cwd}, CLAUDE.md loaded automatically");
         Console.WriteLine();
         return 0;
     }
@@ -85,6 +89,7 @@ public sealed class AddProviderCommand(string provider, bool force = false)
             Directory.CreateDirectory(Path.Combine(root, ".github"));
         if (providers.Contains("gemini"))
             Directory.CreateDirectory(Path.Combine(root, ".gemini"));
+        // cline and aider write to workspace root — no subdirectory needed
     }
 
     private static Dictionary<string, string> BuildVarsFromWorkspace(string root, string projectName)
@@ -175,6 +180,12 @@ public sealed class AddProviderCommand(string provider, bool force = false)
 
         if (resourceName.StartsWith("providers/gemini/"))
             return providers.Contains("gemini") ? resourceName["providers/gemini/".Length..] : null;
+
+        if (resourceName.StartsWith("providers/cline/"))
+            return providers.Contains("cline") ? resourceName["providers/cline/".Length..] : null;
+
+        if (resourceName.StartsWith("providers/aider/"))
+            return providers.Contains("aider") ? resourceName["providers/aider/".Length..] : null;
 
         // nessy reuses .claude/ — extract only if there's no .claude/ already
         if (resourceName.StartsWith(".claude/") && providers.Contains("nessy"))

--- a/tools/setup-cli/MultiagentSetup.csproj
+++ b/tools/setup-cli/MultiagentSetup.csproj
@@ -7,10 +7,10 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>multiagent-setup</ToolCommandName>
     <PackageId>multiagent-setup</PackageId>
-    <Version>1.16.0</Version>
-    <Description>Scaffold a multi-agent AI workspace (Claude, Nessy, Gemini, Codex, Qwen, Cursor, Windsurf, Copilot)</Description>
+    <Version>1.17.0</Version>
+    <Description>Scaffold a multi-agent AI workspace (Claude, Nessy, Gemini, Codex, Qwen, Aider, Cline, Cursor, Windsurf, Copilot)</Description>
     <Authors>Roman Melnikov</Authors>
-    <PackageTags>claude;nessy;gemini;codex;qwen;cursor;windsurf;copilot;ai;multiagent;workspace;orchestrator;developer-tools;agents</PackageTags>
+    <PackageTags>claude;nessy;gemini;codex;qwen;aider;cline;cursor;windsurf;copilot;ai;multiagent;workspace;orchestrator;developer-tools;agents</PackageTags>
     <AssemblyName>MultiagentSetup</AssemblyName>
     <RootNamespace>MultiagentSetup</RootNamespace>
     <PackageReadmeFile>README.md</PackageReadmeFile>
@@ -69,6 +69,13 @@
     <!-- Provider: Gemini -->
     <EmbeddedResource Include="Templates/providers/gemini/.gemini/settings.json" LogicalName="providers/gemini/.gemini/settings.json" />
     <EmbeddedResource Include="Templates/providers/gemini/GEMINI.md" LogicalName="providers/gemini/GEMINI.md" />
+
+    <!-- Provider: Cline -->
+    <EmbeddedResource Include="Templates/providers/cline/.clinerules" LogicalName="providers/cline/.clinerules" />
+
+    <!-- Provider: Aider -->
+    <EmbeddedResource Include="Templates/providers/aider/.aider.conf.yml" LogicalName="providers/aider/.aider.conf.yml" />
+    <EmbeddedResource Include="Templates/providers/aider/AIDER.md" LogicalName="providers/aider/AIDER.md" />
 
     <!-- Tool scripts -->
     <EmbeddedResource Include="Templates/tools/sync-roles.sh" LogicalName="tools/sync-roles.sh" />

--- a/tools/setup-cli/Program.cs
+++ b/tools/setup-cli/Program.cs
@@ -39,9 +39,9 @@ async Task<int> HandleNew(string[] a)
             org ??= a[i];
     }
 
-    string[] validProviders = ["claude", "nessy", "codex", "qwen", "cursor", "windsurf", "copilot", "gemini", "all"];
+    string[] validProviders = ["claude", "nessy", "codex", "qwen", "cursor", "windsurf", "copilot", "gemini", "cline", "aider", "all"];
     if (!validProviders.Contains(provider))
-        return PrintUsage(error: $"Unknown provider '{provider}'. Valid: claude, nessy, codex, qwen, cursor, windsurf, copilot, gemini, all");
+        return PrintUsage(error: $"Unknown provider '{provider}'. Valid: claude, nessy, codex, qwen, cursor, windsurf, copilot, gemini, cline, aider, all");
 
     return await new SetupCommand(name, org, provider).ExecuteAsync();
 }
@@ -54,7 +54,7 @@ async Task<int> HandleAddProvider(string[] a)
 
     bool force = a.Contains("--force");
 
-    string[] validProviders = ["nessy", "codex", "qwen", "cursor", "windsurf", "copilot", "gemini"];
+    string[] validProviders = ["nessy", "codex", "qwen", "cursor", "windsurf", "copilot", "gemini", "cline", "aider"];
 
     if (provider == "all")
     {
@@ -67,7 +67,7 @@ async Task<int> HandleAddProvider(string[] a)
     }
 
     if (!validProviders.Contains(provider))
-        return PrintUsage(error: $"Unknown provider '{provider}'. Valid: nessy, codex, qwen, cursor, windsurf, copilot, gemini, all");
+        return PrintUsage(error: $"Unknown provider '{provider}'. Valid: nessy, codex, qwen, cursor, windsurf, copilot, gemini, cline, aider, all");
 
     return await new AddProviderCommand(provider, force).ExecuteAsync();
 }
@@ -102,9 +102,10 @@ static int PrintUsage(string? error = null)
     Console.WriteLine("Commands:");
     Console.WriteLine("  new <project-name> [github-org]    Create a new multi-agent workspace");
     Console.WriteLine("    --provider <name>                 Provider: claude (default), nessy, codex, qwen,");
-    Console.WriteLine("                                               cursor, windsurf, copilot, gemini, all");
+    Console.WriteLine("                                               cursor, windsurf, copilot, gemini,");
+    Console.WriteLine("                                               cline, aider, all");
     Console.WriteLine("  add-provider <name>                 Add a provider to an existing workspace");
-    Console.WriteLine("    <name>: nessy, codex, qwen, cursor, windsurf, copilot, gemini, all");
+    Console.WriteLine("    <name>: nessy, codex, qwen, cursor, windsurf, copilot, gemini, cline, aider, all");
     Console.WriteLine("    --force                           Overwrite existing provider config");
     Console.WriteLine("  update                              Update workspace templates to latest version");
     Console.WriteLine("    --force                           Overwrite all files (CLAUDE.md preserved by default)");

--- a/tools/setup-cli/SetupCommand.cs
+++ b/tools/setup-cli/SetupCommand.cs
@@ -38,7 +38,7 @@ public sealed class SetupCommand(string projectName, string? requestedOrg, strin
         Console.WriteLine();
 
         var providers = provider == "all"
-            ? new[] { "claude", "codex", "qwen", "cursor", "windsurf", "copilot", "gemini" }
+            ? new[] { "claude", "codex", "qwen", "cursor", "windsurf", "copilot", "gemini", "cline", "aider" }
             : new[] { provider };
 
         CreateDirectories(targetDir, providers);
@@ -86,6 +86,10 @@ public sealed class SetupCommand(string projectName, string? requestedOrg, strin
             Console.WriteLine($"       copilot       → open {targetDir} in VS Code, reads .github/copilot-instructions.md");
         if (providers.Contains("gemini"))
             Console.WriteLine($"       gemini        → /orchestrator <task>");
+        if (providers.Contains("cline"))
+            Console.WriteLine($"       cline         → open {targetDir} in VS Code, .clinerules loads automatically");
+        if (providers.Contains("aider"))
+            Console.WriteLine($"       aider         → run 'aider' from {targetDir}, CLAUDE.md loaded automatically");
         Console.WriteLine();
         return 0;
     }
@@ -98,7 +102,7 @@ public sealed class SetupCommand(string projectName, string? requestedOrg, strin
         ok &= Require("git", macOs: "brew install git",      win: "winget install Git.Git");
         ok &= Require("jq",  macOs: "brew install jq",       win: "winget install jqlang.jq");
         ok &= Require("gh",  macOs: "brew install gh",        win: "winget install GitHub.cli");
-        var providers = provider == "all" ? new[] { "claude", "codex", "qwen", "cursor", "windsurf", "copilot", "gemini" } : new[] { provider };
+        var providers = provider == "all" ? new[] { "claude", "codex", "qwen", "cursor", "windsurf", "copilot", "gemini", "cline", "aider" } : new[] { provider };
         if (providers.Contains("claude"))
             Suggest("claude",     "https://docs.anthropic.com/en/docs/claude-code");
         if (providers.Contains("nessy"))
@@ -115,6 +119,10 @@ public sealed class SetupCommand(string projectName, string? requestedOrg, strin
             Console.WriteLine("  INFO: copilot — GitHub Copilot, install VS Code extension");
         if (providers.Contains("gemini"))
             Suggest("gemini",     "https://ai.google.dev/gemini-api/docs/gemini-cli");
+        if (providers.Contains("cline"))
+            Console.WriteLine("  INFO: cline — VS Code extension, install from marketplace");
+        if (providers.Contains("aider"))
+            Suggest("aider",      "https://aider.chat");
         Console.WriteLine();
         return ok;
     }
@@ -189,6 +197,7 @@ public sealed class SetupCommand(string projectName, string? requestedOrg, strin
             Directory.CreateDirectory(Path.Combine(root, ".github"));
         if (providers.Contains("gemini"))
             Directory.CreateDirectory(Path.Combine(root, ".gemini"));
+        // cline and aider write files to workspace root — no subdirectory needed
     }
 
     // ── Template extraction ───────────────────────────────────────────────────
@@ -259,6 +268,12 @@ public sealed class SetupCommand(string projectName, string? requestedOrg, strin
 
         if (resourceName.StartsWith("providers/gemini/"))
             return providers.Contains("gemini") ? resourceName["providers/gemini/".Length..] : null;
+
+        if (resourceName.StartsWith("providers/cline/"))
+            return providers.Contains("cline") ? resourceName["providers/cline/".Length..] : null;
+
+        if (resourceName.StartsWith("providers/aider/"))
+            return providers.Contains("aider") ? resourceName["providers/aider/".Length..] : null;
 
         // Shared (CLAUDE.md, docs/, tools/)
         return resourceName;

--- a/tools/setup-cli/TemplateResources.cs
+++ b/tools/setup-cli/TemplateResources.cs
@@ -3,11 +3,14 @@ namespace MultiagentSetup;
 internal static class TemplateResources
 {
     internal static bool IsTextResource(string name) =>
-        name.EndsWith(".md")   ||
-        name.EndsWith(".mdc")  ||
-        name.EndsWith(".json") ||
-        name.EndsWith(".toml") ||
-        name.EndsWith(".sh")   ||
-        name.EndsWith(".zsh")  ||
-        name.EndsWith(".ps1");
+        name.EndsWith(".md")    ||
+        name.EndsWith(".mdc")   ||
+        name.EndsWith(".json")  ||
+        name.EndsWith(".toml")  ||
+        name.EndsWith(".sh")    ||
+        name.EndsWith(".zsh")   ||
+        name.EndsWith(".ps1")   ||
+        name.EndsWith(".yml")   ||
+        name.EndsWith(".yaml")  ||
+        name.EndsWith("clinerules"); // .clinerules has no dot-extension match above
 }

--- a/tools/setup-cli/Templates/providers/aider/.aider.conf.yml
+++ b/tools/setup-cli/Templates/providers/aider/.aider.conf.yml
@@ -1,0 +1,22 @@
+# Aider configuration for {{PROJECT_NAME}} multi-agent workspace
+# Full reference: https://aider.chat/docs/config/aider_conf.html
+
+## Always include workspace context in every session
+read:
+  - CLAUDE.md
+  - docs/process.md
+
+## Commit settings — workspace uses conventional commits
+auto-commits: false
+commit-prompt: |
+  Write a conventional commit message for the changes.
+  Format: <type>(<scope>): <description>
+  Types: feat, fix, chore, docs, refactor, test, style, perf, ci
+  Keep subject under 72 characters.
+
+## Disable auto-attribution (workspace team tracks authorship separately)
+attribute-author: false
+attribute-committer: false
+
+## Show diffs before applying (recommended for pipeline work)
+# auto-accept-architect: false

--- a/tools/setup-cli/Templates/providers/aider/AIDER.md
+++ b/tools/setup-cli/Templates/providers/aider/AIDER.md
@@ -1,0 +1,52 @@
+# {{PROJECT_NAME}} — Using Aider
+
+This workspace is configured for [Aider](https://aider.chat) — AI pair programming in the terminal.
+
+## Quick start
+
+```bash
+# From workspace root — CLAUDE.md and docs/process.md are loaded automatically
+aider
+
+# Work on code repo directly
+cd code/{{PROJECT_NAME}}
+aider
+```
+
+## Workspace layout
+
+```
+{{PROJECT_NAME}}/
+├── CLAUDE.md               ← workspace context (auto-loaded by .aider.conf.yml)
+├── docs/
+│   ├── process.md          ← pipeline rules (auto-loaded)
+│   └── role-capabilities.md
+├── code/{{PROJECT_NAME}}/  ← main code repo
+└── .aider.conf.yml         ← Aider config (this provider)
+```
+
+## Multi-agent pipeline
+
+Aider handles **BUILD** and **TEST** phases. Use the full pipeline for larger features:
+
+```
+PLAN → BUILD (aider) → TEST (aider) → VERIFY → SHIP
+```
+
+**PLAN** with Claude/orchestrator, **BUILD** with Aider, **VERIFY** with code reviewer.
+
+## Tips
+
+- Use `/add docs/role-capabilities.md` to include the capability index
+- Use `/architect` mode for architecture decisions before coding
+- Use `/ask` for questions without code changes
+- Keep commits conventional: `feat:`, `fix:`, `chore:`, etc.
+
+## Agent roles
+
+Roles live in `.claude/commands/` as slash commands for other agents (Claude, Gemini, etc.).
+Aider doesn't use slash commands — use Aider for code, other agents for strategy and review.
+
+## GitHub org
+
+`{{GITHUB_ORG}}/{{GITHUB_REPO}}`

--- a/tools/setup-cli/Templates/providers/cline/.clinerules
+++ b/tools/setup-cli/Templates/providers/cline/.clinerules
@@ -1,0 +1,68 @@
+# {{PROJECT_NAME}} — Multi-Agent Workspace
+
+{{PROJECT_DESCRIPTION}}
+
+**Founder:** {{FOUNDER}}. **Phase:** {{PHASE}}.
+
+---
+
+## How to start
+
+### Determine mode
+
+| Request type | Mode | What to do |
+|---|---|---|
+| `/orchestrator <task>` | **Orchestrator** | Read `docs/process.md`, then execute pipeline |
+| `/<role> <question>` | **Single Expert** | Answer as that role, no pipeline |
+| Direct question | **Chief of Staff** | Advise, suggest next step or role |
+
+### Load context
+
+- `CLAUDE.md` — workspace overview (always)
+- `docs/process.md` — pipeline rules (if orchestrating)
+- `docs/role-capabilities.md` — role capability index
+
+---
+
+## Workspace structure
+
+```
+{{PROJECT_NAME}}/
+├── code/{{PROJECT_NAME}}/   ← code repo (own CLAUDE.md)
+├── docs/
+│   ├── process.md           ← operational manual
+│   ├── role-capabilities.md ← role capability index
+│   └── workflows/           ← workflow specs
+├── .claude/
+│   └── commands/            ← slash command roles
+```
+
+## Agent roles
+
+**Orchestrator** (`/orchestrator`) — autonomous pipeline manager. Reads `docs/process.md`, delegates to roles, validates outputs.
+
+**Roles** available via slash commands in `.claude/commands/`:
+
+| Layer | Key roles |
+|---|---|
+| Strategy | `/product-manager`, `/product-trend-researcher` |
+| Engineering | `/engineering-software-architect`, `/engineering-backend-architect`, `/engineering-frontend-developer`, `/engineering-code-reviewer` |
+| Design | `/design-ux-researcher`, `/design-ui-designer` |
+| GTM | `/specialized-developer-advocate`, `/engineering-technical-writer` |
+
+## Pipeline
+
+```
+PLAN → BUILD → TEST → VERIFY → SHIP
+```
+
+5 types: feature, bugfix (skip PLAN), infra, content, spike (PLAN only).
+
+Full details: `docs/process.md`.
+
+## Rules
+
+- **Code changes**: work in `code/{{PROJECT_NAME}}/` only
+- **Git discipline**: `git status` before commit, no `git init` in existing repo
+- **Don't overengineer**: working first, pretty later
+- **Confirm intent**: clarify ambiguous requests before acting

--- a/tools/setup-cli/Templates/tools/completions.ps1
+++ b/tools/setup-cli/Templates/tools/completions.ps1
@@ -27,7 +27,7 @@ Register-ArgumentCompleter -Native -CommandName multiagent-setup -ScriptBlock {
     # Complete --provider values when previous token is --provider
     $prevToken = if ($tokens.Count -ge 2) { $tokens[-2].ToString() } else { "" }
     if ($prevToken -eq '--provider') {
-        @('claude', 'nessy', 'gemini', 'codex', 'qwen', 'cursor', 'windsurf', 'copilot', 'all') |
+        @('claude', 'nessy', 'gemini', 'codex', 'qwen', 'cursor', 'windsurf', 'copilot', 'cline', 'aider', 'all') |
         Where-Object { $_ -like "$wordToComplete*" } | ForEach-Object {
             [System.Management.Automation.CompletionResult]::new($_, $_, 'ParameterValue', $_)
         }
@@ -43,7 +43,7 @@ Register-ArgumentCompleter -Native -CommandName multiagent-setup -ScriptBlock {
         }
         'add-provider' {
             if ($tokens.Count -eq 1 -or ($tokens.Count -eq 2 -and $wordToComplete)) {
-                @('claude', 'nessy', 'gemini', 'codex', 'qwen', 'cursor', 'windsurf', 'copilot', 'all') | Where-Object { $_ -like "$wordToComplete*" } | ForEach-Object {
+                @('claude', 'nessy', 'gemini', 'codex', 'qwen', 'cursor', 'windsurf', 'copilot', 'cline', 'aider', 'all') | Where-Object { $_ -like "$wordToComplete*" } | ForEach-Object {
                     [System.Management.Automation.CompletionResult]::new($_, $_, 'ParameterValue', $_)
                 }
             } else {

--- a/tools/setup-cli/Templates/tools/completions.zsh
+++ b/tools/setup-cli/Templates/tools/completions.zsh
@@ -48,6 +48,8 @@ _multiagent_setup() {
     'cursor:Cursor IDE'
     'windsurf:Windsurf IDE by Codeium'
     'copilot:GitHub Copilot in VS Code'
+    'cline:Cline extension for VS Code'
+    'aider:Aider AI pair programmer'
     'all:All providers at once'
   )
   hooks=(


### PR DESCRIPTION
## Summary

- Adds **Cline** provider (`--provider cline` / `add-provider cline`) — generates `.clinerules` for VS Code Cline and Roo Code extensions
- Adds **Aider** provider (`--provider aider` / `add-provider aider`) — generates `.aider.conf.yml` that auto-reads `CLAUDE.md` + `docs/process.md`, and `AIDER.md` docs
- Both providers included in `--provider all`
- `TemplateResources.IsTextResource` extended for `.yml`, `.yaml`, `.clinerules`
- Shell completions (zsh + PowerShell) updated
- Bumps to v1.17.0

## Test plan

- [ ] `multiagent-setup new my-proj --provider cline` — check `.clinerules` created with substituted vars
- [ ] `multiagent-setup new my-proj --provider aider` — check `.aider.conf.yml` and `AIDER.md` created
- [ ] `multiagent-setup add-provider cline` in existing workspace — check `.clinerules` appears
- [ ] `multiagent-setup add-provider aider` — check `.aider.conf.yml` and `AIDER.md` appear
- [ ] `multiagent-setup new my-proj --provider all` — verify cline and aider files included
- [ ] Tab complete `--provider` shows `cline` and `aider`