### PR TITLE
feat: add Continue.dev provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Version
 
 ---
 
+## [1.18.0] — 2026-04-09
+
+### Added
+- **Continue.dev provider** (`--provider continue` / `add-provider continue`) — generates `.continue/config.yaml` with custom `/orchestrator` and `/expert` slash commands and workspace rules; works with VS Code and JetBrains via the Continue extension
+
+---
+
 ## [1.17.0] — 2026-04-09
 
 ### Added

--- a/tools/setup-cli/AddProviderCommand.cs
+++ b/tools/setup-cli/AddProviderCommand.cs
@@ -66,6 +66,8 @@ public sealed class AddProviderCommand(string provider, bool force = false)
             Console.WriteLine($"  cline         → open {cwd} in VS Code with Cline extension, .clinerules loads automatically");
         else if (provider is "aider")
             Console.WriteLine($"  aider         → run 'aider' from {cwd}, CLAUDE.md loaded automatically");
+        else if (provider is "continue")
+            Console.WriteLine($"  continue      → open {cwd} in VS Code/JetBrains, rules load from .continue/config.yaml");
         Console.WriteLine();
         return 0;
     }
@@ -89,6 +91,8 @@ public sealed class AddProviderCommand(string provider, bool force = false)
             Directory.CreateDirectory(Path.Combine(root, ".github"));
         if (providers.Contains("gemini"))
             Directory.CreateDirectory(Path.Combine(root, ".gemini"));
+        if (providers.Contains("continue"))
+            Directory.CreateDirectory(Path.Combine(root, ".continue"));
         // cline and aider write to workspace root — no subdirectory needed
     }
 
@@ -186,6 +190,9 @@ public sealed class AddProviderCommand(string provider, bool force = false)
 
         if (resourceName.StartsWith("providers/aider/"))
             return providers.Contains("aider") ? resourceName["providers/aider/".Length..] : null;
+
+        if (resourceName.StartsWith("providers/continue/"))
+            return providers.Contains("continue") ? resourceName["providers/continue/".Length..] : null;
 
         // nessy reuses .claude/ — extract only if there's no .claude/ already
         if (resourceName.StartsWith(".claude/") && providers.Contains("nessy"))

--- a/tools/setup-cli/MultiagentSetup.csproj
+++ b/tools/setup-cli/MultiagentSetup.csproj
@@ -7,10 +7,10 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>multiagent-setup</ToolCommandName>
     <PackageId>multiagent-setup</PackageId>
-    <Version>1.17.0</Version>
-    <Description>Scaffold a multi-agent AI workspace (Claude, Nessy, Gemini, Codex, Qwen, Aider, Cline, Cursor, Windsurf, Copilot)</Description>
+    <Version>1.18.0</Version>
+    <Description>Scaffold a multi-agent AI workspace (Claude, Nessy, Gemini, Codex, Qwen, Aider, Cline, Continue, Cursor, Windsurf, Copilot)</Description>
     <Authors>Roman Melnikov</Authors>
-    <PackageTags>claude;nessy;gemini;codex;qwen;aider;cline;cursor;windsurf;copilot;ai;multiagent;workspace;orchestrator;developer-tools;agents</PackageTags>
+    <PackageTags>claude;nessy;gemini;codex;qwen;aider;cline;continue;cursor;windsurf;copilot;ai;multiagent;workspace;orchestrator;developer-tools;agents</PackageTags>
     <AssemblyName>MultiagentSetup</AssemblyName>
     <RootNamespace>MultiagentSetup</RootNamespace>
     <PackageReadmeFile>README.md</PackageReadmeFile>
@@ -76,6 +76,10 @@
     <!-- Provider: Aider -->
     <EmbeddedResource Include="Templates/providers/aider/.aider.conf.yml" LogicalName="providers/aider/.aider.conf.yml" />
     <EmbeddedResource Include="Templates/providers/aider/AIDER.md" LogicalName="providers/aider/AIDER.md" />
+
+    <!-- Provider: Continue.dev -->
+    <EmbeddedResource Include="Templates/providers/continue/.continue/config.yaml" LogicalName="providers/continue/.continue/config.yaml" />
+    <EmbeddedResource Include="Templates/providers/continue/CONTINUE.md" LogicalName="providers/continue/CONTINUE.md" />
 
     <!-- Tool scripts -->
     <EmbeddedResource Include="Templates/tools/sync-roles.sh" LogicalName="tools/sync-roles.sh" />

--- a/tools/setup-cli/Program.cs
+++ b/tools/setup-cli/Program.cs
@@ -39,9 +39,9 @@ async Task<int> HandleNew(string[] a)
             org ??= a[i];
     }
 
-    string[] validProviders = ["claude", "nessy", "codex", "qwen", "cursor", "windsurf", "copilot", "gemini", "cline", "aider", "all"];
+    string[] validProviders = ["claude", "nessy", "codex", "qwen", "cursor", "windsurf", "copilot", "gemini", "cline", "aider", "continue", "all"];
     if (!validProviders.Contains(provider))
-        return PrintUsage(error: $"Unknown provider '{provider}'. Valid: claude, nessy, codex, qwen, cursor, windsurf, copilot, gemini, cline, aider, all");
+        return PrintUsage(error: $"Unknown provider '{provider}'. Valid: claude, nessy, codex, qwen, cursor, windsurf, copilot, gemini, cline, aider, continue, all");
 
     return await new SetupCommand(name, org, provider).ExecuteAsync();
 }
@@ -54,7 +54,7 @@ async Task<int> HandleAddProvider(string[] a)
 
     bool force = a.Contains("--force");
 
-    string[] validProviders = ["nessy", "codex", "qwen", "cursor", "windsurf", "copilot", "gemini", "cline", "aider"];
+    string[] validProviders = ["nessy", "codex", "qwen", "cursor", "windsurf", "copilot", "gemini", "cline", "aider", "continue"];
 
     if (provider == "all")
     {
@@ -67,7 +67,7 @@ async Task<int> HandleAddProvider(string[] a)
     }
 
     if (!validProviders.Contains(provider))
-        return PrintUsage(error: $"Unknown provider '{provider}'. Valid: nessy, codex, qwen, cursor, windsurf, copilot, gemini, cline, aider, all");
+        return PrintUsage(error: $"Unknown provider '{provider}'. Valid: nessy, codex, qwen, cursor, windsurf, copilot, gemini, cline, aider, continue, all");
 
     return await new AddProviderCommand(provider, force).ExecuteAsync();
 }
@@ -103,9 +103,9 @@ static int PrintUsage(string? error = null)
     Console.WriteLine("  new <project-name> [github-org]    Create a new multi-agent workspace");
     Console.WriteLine("    --provider <name>                 Provider: claude (default), nessy, codex, qwen,");
     Console.WriteLine("                                               cursor, windsurf, copilot, gemini,");
-    Console.WriteLine("                                               cline, aider, all");
+    Console.WriteLine("                                               cline, aider, continue, all");
     Console.WriteLine("  add-provider <name>                 Add a provider to an existing workspace");
-    Console.WriteLine("    <name>: nessy, codex, qwen, cursor, windsurf, copilot, gemini, cline, aider, all");
+    Console.WriteLine("    <name>: nessy, codex, qwen, cursor, windsurf, copilot, gemini, cline, aider, continue, all");
     Console.WriteLine("    --force                           Overwrite existing provider config");
     Console.WriteLine("  update                              Update workspace templates to latest version");
     Console.WriteLine("    --force                           Overwrite all files (CLAUDE.md preserved by default)");

--- a/tools/setup-cli/SetupCommand.cs
+++ b/tools/setup-cli/SetupCommand.cs
@@ -38,7 +38,7 @@ public sealed class SetupCommand(string projectName, string? requestedOrg, strin
         Console.WriteLine();
 
         var providers = provider == "all"
-            ? new[] { "claude", "codex", "qwen", "cursor", "windsurf", "copilot", "gemini", "cline", "aider" }
+            ? new[] { "claude", "codex", "qwen", "cursor", "windsurf", "copilot", "gemini", "cline", "aider", "continue" }
             : new[] { provider };
 
         CreateDirectories(targetDir, providers);
@@ -90,6 +90,8 @@ public sealed class SetupCommand(string projectName, string? requestedOrg, strin
             Console.WriteLine($"       cline         → open {targetDir} in VS Code, .clinerules loads automatically");
         if (providers.Contains("aider"))
             Console.WriteLine($"       aider         → run 'aider' from {targetDir}, CLAUDE.md loaded automatically");
+        if (providers.Contains("continue"))
+            Console.WriteLine($"       continue      → open {targetDir} in VS Code/JetBrains, rules load from .continue/config.yaml");
         Console.WriteLine();
         return 0;
     }
@@ -102,7 +104,7 @@ public sealed class SetupCommand(string projectName, string? requestedOrg, strin
         ok &= Require("git", macOs: "brew install git",      win: "winget install Git.Git");
         ok &= Require("jq",  macOs: "brew install jq",       win: "winget install jqlang.jq");
         ok &= Require("gh",  macOs: "brew install gh",        win: "winget install GitHub.cli");
-        var providers = provider == "all" ? new[] { "claude", "codex", "qwen", "cursor", "windsurf", "copilot", "gemini", "cline", "aider" } : new[] { provider };
+        var providers = provider == "all" ? new[] { "claude", "codex", "qwen", "cursor", "windsurf", "copilot", "gemini", "cline", "aider", "continue" } : new[] { provider };
         if (providers.Contains("claude"))
             Suggest("claude",     "https://docs.anthropic.com/en/docs/claude-code");
         if (providers.Contains("nessy"))
@@ -123,6 +125,8 @@ public sealed class SetupCommand(string projectName, string? requestedOrg, strin
             Console.WriteLine("  INFO: cline — VS Code extension, install from marketplace");
         if (providers.Contains("aider"))
             Suggest("aider",      "https://aider.chat");
+        if (providers.Contains("continue"))
+            Console.WriteLine("  INFO: continue — VS Code/JetBrains extension, install from https://continue.dev");
         Console.WriteLine();
         return ok;
     }
@@ -197,6 +201,8 @@ public sealed class SetupCommand(string projectName, string? requestedOrg, strin
             Directory.CreateDirectory(Path.Combine(root, ".github"));
         if (providers.Contains("gemini"))
             Directory.CreateDirectory(Path.Combine(root, ".gemini"));
+        if (providers.Contains("continue"))
+            Directory.CreateDirectory(Path.Combine(root, ".continue"));
         // cline and aider write files to workspace root — no subdirectory needed
     }
 
@@ -274,6 +280,9 @@ public sealed class SetupCommand(string projectName, string? requestedOrg, strin
 
         if (resourceName.StartsWith("providers/aider/"))
             return providers.Contains("aider") ? resourceName["providers/aider/".Length..] : null;
+
+        if (resourceName.StartsWith("providers/continue/"))
+            return providers.Contains("continue") ? resourceName["providers/continue/".Length..] : null;
 
         // Shared (CLAUDE.md, docs/, tools/)
         return resourceName;

--- a/tools/setup-cli/Templates/providers/continue/.continue/config.yaml
+++ b/tools/setup-cli/Templates/providers/continue/.continue/config.yaml
@@ -1,0 +1,47 @@
+# Continue.dev config for {{PROJECT_NAME}} multi-agent workspace
+# Full reference: https://docs.continue.dev/reference/config
+
+## Custom slash commands — invoke agent roles directly in Continue
+customCommands:
+  - name: orchestrator
+    description: "Run the orchestrator pipeline for a task"
+    prompt: |
+      You are the Orchestrator for the {{PROJECT_NAME}} multi-agent workspace.
+
+      Read docs/process.md for the operational pipeline and gate rules.
+      Read docs/role-capabilities.md to select the right specialist roles.
+
+      Task: {{{ input }}}
+
+      Execute the appropriate pipeline (feature/bugfix/infra/content/spike).
+      Delegate all code changes to engineering roles — never write code yourself.
+
+  - name: expert
+    description: "Ask a specialist role a question (e.g. /expert architect: how should I structure this?)"
+    prompt: |
+      You are the {{PROJECT_NAME}} Chief of Staff.
+      The user wants a specialist answer. Role hinted: {{{ input }}}
+      Answer as that role. Be concise and expert.
+
+## Always load workspace context in every chat session
+context:
+  - provider: file
+    params:
+      nRetrieve: 5
+      nFinal: 3
+
+## Rules applied to every chat (equivalent to system prompt additions)
+rules:
+  - name: "{{PROJECT_NAME}} workspace"
+    rule: |
+      This is the {{PROJECT_NAME}} multi-agent workspace.
+      {{PROJECT_DESCRIPTION}}
+
+      Workspace structure:
+      - CLAUDE.md — workspace overview and agent team
+      - docs/process.md — pipeline rules (PLAN→BUILD→TEST→VERIFY→SHIP)
+      - docs/role-capabilities.md — specialist roles index
+      - code/{{PROJECT_NAME}}/ — main code repository
+
+      Always read CLAUDE.md before answering workspace questions.
+      For pipeline tasks, use /orchestrator. For quick expert questions, use /expert.

--- a/tools/setup-cli/Templates/providers/continue/CONTINUE.md
+++ b/tools/setup-cli/Templates/providers/continue/CONTINUE.md
@@ -1,0 +1,60 @@
+# {{PROJECT_NAME}} — Using Continue.dev
+
+This workspace is configured for [Continue.dev](https://continue.dev) — the open-source AI code assistant for VS Code and JetBrains.
+
+## Quick start
+
+1. Install [Continue extension](https://marketplace.visualstudio.com/items?itemName=Continue.continue) in VS Code or JetBrains
+2. Open this workspace folder
+3. Open Continue sidebar (`Ctrl+L` / `Cmd+L`) — workspace rules load automatically
+
+## Custom slash commands
+
+| Command | Description |
+|---|---|
+| `/orchestrator <task>` | Run the full multi-agent pipeline |
+| `/expert <role>: <question>` | Ask a specialist role directly |
+
+### Example: run a feature pipeline
+
+```
+/orchestrator Add user authentication with JWT tokens to the API
+```
+
+### Example: ask an architect
+
+```
+/expert architect: What's the best way to structure the database layer?
+```
+
+## Workspace layout
+
+```
+{{PROJECT_NAME}}/
+├── CLAUDE.md               ← workspace context (auto-loaded via rules)
+├── docs/
+│   ├── process.md          ← pipeline rules (PLAN→BUILD→TEST→VERIFY→SHIP)
+│   └── role-capabilities.md ← specialist roles index
+├── code/{{PROJECT_NAME}}/  ← main code repo
+└── .continue/
+    └── config.yaml         ← Continue config (this provider)
+```
+
+## Adding context manually
+
+In the Continue chat, use `@` to add files:
+- `@CLAUDE.md` — workspace overview
+- `@docs/process.md` — pipeline rules
+- `@docs/role-capabilities.md` — role index
+
+## Pipeline
+
+```
+PLAN → BUILD → TEST → VERIFY → SHIP
+```
+
+Use `/orchestrator` for full pipeline execution. Use Continue's inline edit (`Ctrl+I`) for BUILD/TEST steps.
+
+## GitHub
+
+`{{GITHUB_ORG}}/{{GITHUB_REPO}}`

--- a/tools/setup-cli/Templates/tools/completions.ps1
+++ b/tools/setup-cli/Templates/tools/completions.ps1
@@ -27,7 +27,7 @@ Register-ArgumentCompleter -Native -CommandName multiagent-setup -ScriptBlock {
     # Complete --provider values when previous token is --provider
     $prevToken = if ($tokens.Count -ge 2) { $tokens[-2].ToString() } else { "" }
     if ($prevToken -eq '--provider') {
-        @('claude', 'nessy', 'gemini', 'codex', 'qwen', 'cursor', 'windsurf', 'copilot', 'cline', 'aider', 'all') |
+        @('claude', 'nessy', 'gemini', 'codex', 'qwen', 'cursor', 'windsurf', 'copilot', 'cline', 'aider', 'continue', 'all') |
         Where-Object { $_ -like "$wordToComplete*" } | ForEach-Object {
             [System.Management.Automation.CompletionResult]::new($_, $_, 'ParameterValue', $_)
         }
@@ -43,7 +43,7 @@ Register-ArgumentCompleter -Native -CommandName multiagent-setup -ScriptBlock {
         }
         'add-provider' {
             if ($tokens.Count -eq 1 -or ($tokens.Count -eq 2 -and $wordToComplete)) {
-                @('claude', 'nessy', 'gemini', 'codex', 'qwen', 'cursor', 'windsurf', 'copilot', 'cline', 'aider', 'all') | Where-Object { $_ -like "$wordToComplete*" } | ForEach-Object {
+                @('claude', 'nessy', 'gemini', 'codex', 'qwen', 'cursor', 'windsurf', 'copilot', 'cline', 'aider', 'continue', 'all') | Where-Object { $_ -like "$wordToComplete*" } | ForEach-Object {
                     [System.Management.Automation.CompletionResult]::new($_, $_, 'ParameterValue', $_)
                 }
             } else {

--- a/tools/setup-cli/Templates/tools/completions.zsh
+++ b/tools/setup-cli/Templates/tools/completions.zsh
@@ -50,6 +50,7 @@ _multiagent_setup() {
     'copilot:GitHub Copilot in VS Code'
     'cline:Cline extension for VS Code'
     'aider:Aider AI pair programmer'
+    'continue:Continue.dev VS Code/JetBrains extension'
     'all:All providers at once'
   )
   hooks=(


### PR DESCRIPTION
## Summary

- Adds **Continue.dev** provider (`--provider continue` / `add-provider continue`)
- Generates `.continue/config.yaml` with custom slash commands: `/orchestrator` and `/expert`
- Workspace rules auto-loaded in every Continue chat session
- Works with VS Code and JetBrains via the [Continue extension](https://continue.dev)
- Included in `--provider all`
- Bumps to v1.18.0

## Test plan

- [ ] `multiagent-setup new my-proj --provider continue` — check `.continue/config.yaml` and `CONTINUE.md` created with substituted vars
- [ ] `multiagent-setup add-provider continue` in existing workspace — check `.continue/` directory created
- [ ] Tab-complete `--provider` shows `continue`