### PR TITLE
feat: add GitHub Actions orchestrator workflow template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Version
 
 ---
 
+## [1.19.0] — 2026-04-09
+
+### Added
+- **GitHub Actions workflow** (`.github/workflows/orchestrator.yml`) scaffolded for claude/nessy workspaces — run the autonomous orchestrator in CI via `workflow_dispatch`, issue label trigger (`orchestrator`), or scheduled cron; uses environment variables for all GitHub context data to prevent injection (CWE-78)
+
+---
+
 ## [1.18.0] — 2026-04-09
 
 ### Added

--- a/tools/setup-cli/MultiagentSetup.csproj
+++ b/tools/setup-cli/MultiagentSetup.csproj
@@ -7,7 +7,7 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>multiagent-setup</ToolCommandName>
     <PackageId>multiagent-setup</PackageId>
-    <Version>1.18.0</Version>
+    <Version>1.19.0</Version>
     <Description>Scaffold a multi-agent AI workspace (Claude, Nessy, Gemini, Codex, Qwen, Aider, Cline, Continue, Cursor, Windsurf, Copilot)</Description>
     <Authors>Roman Melnikov</Authors>
     <PackageTags>claude;nessy;gemini;codex;qwen;aider;cline;continue;cursor;windsurf;copilot;ai;multiagent;workspace;orchestrator;developer-tools;agents</PackageTags>
@@ -44,6 +44,9 @@
 
     <!-- Hooks -->
     <EmbeddedResource Include="Templates/.claude/hooks/lint.json" LogicalName=".claude/hooks/lint.json" />
+
+    <!-- GitHub Actions workflow -->
+    <EmbeddedResource Include="Templates/.github/workflows/orchestrator.yml" LogicalName=".github/workflows/orchestrator.yml" />
 
     <!-- Provider: Codex -->
     <EmbeddedResource Include="Templates/providers/codex/.codex/config.toml" LogicalName="providers/codex/.codex/config.toml" />

--- a/tools/setup-cli/SetupCommand.cs
+++ b/tools/setup-cli/SetupCommand.cs
@@ -188,6 +188,7 @@ public sealed class SetupCommand(string projectName, string? requestedOrg, strin
         {
             Directory.CreateDirectory(Path.Combine(root, ".claude", "commands"));
             Directory.CreateDirectory(Path.Combine(root, ".claude", "hooks"));
+            Directory.CreateDirectory(Path.Combine(root, ".github", "workflows"));
         }
         if (providers.Contains("codex"))
             Directory.CreateDirectory(Path.Combine(root, ".codex", "skills"));
@@ -255,6 +256,10 @@ public sealed class SetupCommand(string projectName, string? requestedOrg, strin
     private static string? ResolveOutputPath(string resourceName, string[] providers)
     {
         if (resourceName.StartsWith(".claude/"))
+            return (providers.Contains("claude") || providers.Contains("nessy")) ? resourceName : null;
+
+        // GitHub Actions workflow — scaffold for claude/nessy (or any provider that has a code pipeline)
+        if (resourceName == ".github/workflows/orchestrator.yml")
             return (providers.Contains("claude") || providers.Contains("nessy")) ? resourceName : null;
 
         if (resourceName.StartsWith("providers/codex/"))

--- a/tools/setup-cli/Templates/.github/workflows/orchestrator.yml
+++ b/tools/setup-cli/Templates/.github/workflows/orchestrator.yml
@@ -1,0 +1,88 @@
+# Autonomous Orchestrator — runs the multi-agent pipeline in CI
+#
+# Triggers:
+#   • workflow_dispatch — manual run with a task description
+#   • schedule          — nightly autonomous backlog processing (optional)
+#   • issues labeled    — run when an issue gets the 'orchestrator' label
+#
+# Required secrets:
+#   ANTHROPIC_API_KEY — Claude API key (Settings → Secrets → Actions)
+#
+# Usage:
+#   1. Enable this workflow by committing to your workspace repo
+#   2. Go to Actions → Autonomous Orchestrator → Run workflow
+#   3. Enter your task (or leave blank for autonomous backlog mode)
+
+name: Autonomous Orchestrator
+
+on:
+  workflow_dispatch:
+    inputs:
+      task:
+        description: "Task for the orchestrator (leave blank for autonomous backlog mode)"
+        required: false
+        default: ""
+  issues:
+    types: [labeled]
+  # Uncomment to enable nightly autonomous runs:
+  # schedule:
+  #   - cron: '0 8 * * 1-5'   # 8:00 UTC, Mon–Fri
+
+jobs:
+  orchestrate:
+    # Only run on issues if labeled with 'orchestrator'
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'schedule' ||
+      (github.event_name == 'issues' && github.event.label.name == 'orchestrator')
+
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout workspace
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Install Claude Code
+        run: npm install -g @anthropic-ai/claude-code
+
+      - name: Set up git identity
+        run: |
+          git config --global user.name "orchestrator[bot]"
+          git config --global user.email "orchestrator@users.noreply.github.com"
+
+      - name: Build task prompt
+        id: task
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+          INPUT_TASK: ${{ inputs.task }}
+        run: |
+          if [ "$EVENT_NAME" = "issues" ]; then
+            echo "prompt=/orchestrator #${ISSUE_NUMBER}: ${ISSUE_TITLE}" >> "$GITHUB_OUTPUT"
+          elif [ -n "$INPUT_TASK" ]; then
+            echo "prompt=/orchestrator ${INPUT_TASK}" >> "$GITHUB_OUTPUT"
+          else
+            echo "prompt=/orchestrator Pick the top task from the GitHub backlog and execute it." >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run orchestrator
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ORCHESTRATOR_PROMPT: ${{ steps.task.outputs.prompt }}
+        run: |
+          claude --print "$ORCHESTRATOR_PROMPT" \
+                 --max-turns 50 \
+                 --output-format text


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/orchestrator.yml` scaffolded for claude/nessy workspaces
- Triggers: `workflow_dispatch` (manual with task input), issue `orchestrator` label, optional cron schedule
- All GitHub context data passed via `env:` (no injection risk)
- Requires `ANTHROPIC_API_KEY` secret
- Bumps to v1.19.0

## Security

All `${{ github.event.* }}` values use intermediate environment variables in `run:` steps (CWE-78 safe).

## Test plan

- [ ] `multiagent-setup new my-proj` — check `.github/workflows/orchestrator.yml` created
- [ ] `multiagent-setup new my-proj --provider codex` — check workflow NOT created (claude/nessy only)
- [ ] Run workflow manually in a test repo