### PR TITLE
feat: add Roo Code provider (v1.20.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Version
 
 ---
 
+## [1.20.0] — 2026-04-09
+
+### Added
+- **Roo Code provider** (`--provider roo` / `add-provider roo`) — generates `.roo/rules/workspace.md` for the Roo Code VS Code extension; rules load automatically per project from `.roo/rules/` directory (distinct format from Cline's `.clinerules`)
+- Roo Code included in `--provider all`
+- Shell completions (zsh + PowerShell) updated for `roo`
+
+---
+
 ## [1.19.0] — 2026-04-09
 
 ### Added

--- a/tools/setup-cli/AddProviderCommand.cs
+++ b/tools/setup-cli/AddProviderCommand.cs
@@ -68,6 +68,8 @@ public sealed class AddProviderCommand(string provider, bool force = false)
             Console.WriteLine($"  aider         → run 'aider' from {cwd}, CLAUDE.md loaded automatically");
         else if (provider is "continue")
             Console.WriteLine($"  continue      → open {cwd} in VS Code/JetBrains, rules load from .continue/config.yaml");
+        else if (provider is "roo")
+            Console.WriteLine($"  roo           → open {cwd} in VS Code with Roo Code extension, .roo/rules/ loads automatically");
         Console.WriteLine();
         return 0;
     }
@@ -93,6 +95,8 @@ public sealed class AddProviderCommand(string provider, bool force = false)
             Directory.CreateDirectory(Path.Combine(root, ".gemini"));
         if (providers.Contains("continue"))
             Directory.CreateDirectory(Path.Combine(root, ".continue"));
+        if (providers.Contains("roo"))
+            Directory.CreateDirectory(Path.Combine(root, ".roo", "rules"));
         // cline and aider write to workspace root — no subdirectory needed
     }
 
@@ -193,6 +197,9 @@ public sealed class AddProviderCommand(string provider, bool force = false)
 
         if (resourceName.StartsWith("providers/continue/"))
             return providers.Contains("continue") ? resourceName["providers/continue/".Length..] : null;
+
+        if (resourceName.StartsWith("providers/roo/"))
+            return providers.Contains("roo") ? resourceName["providers/roo/".Length..] : null;
 
         // nessy reuses .claude/ — extract only if there's no .claude/ already
         if (resourceName.StartsWith(".claude/") && providers.Contains("nessy"))

--- a/tools/setup-cli/MultiagentSetup.csproj
+++ b/tools/setup-cli/MultiagentSetup.csproj
@@ -7,10 +7,10 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>multiagent-setup</ToolCommandName>
     <PackageId>multiagent-setup</PackageId>
-    <Version>1.19.0</Version>
-    <Description>Scaffold a multi-agent AI workspace (Claude, Nessy, Gemini, Codex, Qwen, Aider, Cline, Continue, Cursor, Windsurf, Copilot)</Description>
+    <Version>1.20.0</Version>
+    <Description>Scaffold a multi-agent AI workspace (Claude, Nessy, Gemini, Codex, Qwen, Aider, Cline, Roo Code, Continue, Cursor, Windsurf, Copilot)</Description>
     <Authors>Roman Melnikov</Authors>
-    <PackageTags>claude;nessy;gemini;codex;qwen;aider;cline;continue;cursor;windsurf;copilot;ai;multiagent;workspace;orchestrator;developer-tools;agents</PackageTags>
+    <PackageTags>claude;nessy;gemini;codex;qwen;aider;cline;roo;continue;cursor;windsurf;copilot;ai;multiagent;workspace;orchestrator;developer-tools;agents</PackageTags>
     <AssemblyName>MultiagentSetup</AssemblyName>
     <RootNamespace>MultiagentSetup</RootNamespace>
     <PackageReadmeFile>README.md</PackageReadmeFile>
@@ -83,6 +83,9 @@
     <!-- Provider: Continue.dev -->
     <EmbeddedResource Include="Templates/providers/continue/.continue/config.yaml" LogicalName="providers/continue/.continue/config.yaml" />
     <EmbeddedResource Include="Templates/providers/continue/CONTINUE.md" LogicalName="providers/continue/CONTINUE.md" />
+
+    <!-- Provider: Roo Code -->
+    <EmbeddedResource Include="Templates/providers/roo/.roo/rules/workspace.md" LogicalName="providers/roo/.roo/rules/workspace.md" />
 
     <!-- Tool scripts -->
     <EmbeddedResource Include="Templates/tools/sync-roles.sh" LogicalName="tools/sync-roles.sh" />

--- a/tools/setup-cli/Program.cs
+++ b/tools/setup-cli/Program.cs
@@ -39,9 +39,9 @@ async Task<int> HandleNew(string[] a)
             org ??= a[i];
     }
 
-    string[] validProviders = ["claude", "nessy", "codex", "qwen", "cursor", "windsurf", "copilot", "gemini", "cline", "aider", "continue", "all"];
+    string[] validProviders = ["claude", "nessy", "codex", "qwen", "cursor", "windsurf", "copilot", "gemini", "cline", "aider", "continue", "roo", "all"];
     if (!validProviders.Contains(provider))
-        return PrintUsage(error: $"Unknown provider '{provider}'. Valid: claude, nessy, codex, qwen, cursor, windsurf, copilot, gemini, cline, aider, continue, all");
+        return PrintUsage(error: $"Unknown provider '{provider}'. Valid: claude, nessy, codex, qwen, cursor, windsurf, copilot, gemini, cline, aider, continue, roo, all");
 
     return await new SetupCommand(name, org, provider).ExecuteAsync();
 }
@@ -54,7 +54,7 @@ async Task<int> HandleAddProvider(string[] a)
 
     bool force = a.Contains("--force");
 
-    string[] validProviders = ["nessy", "codex", "qwen", "cursor", "windsurf", "copilot", "gemini", "cline", "aider", "continue"];
+    string[] validProviders = ["nessy", "codex", "qwen", "cursor", "windsurf", "copilot", "gemini", "cline", "aider", "continue", "roo"];
 
     if (provider == "all")
     {
@@ -67,7 +67,7 @@ async Task<int> HandleAddProvider(string[] a)
     }
 
     if (!validProviders.Contains(provider))
-        return PrintUsage(error: $"Unknown provider '{provider}'. Valid: nessy, codex, qwen, cursor, windsurf, copilot, gemini, cline, aider, continue, all");
+        return PrintUsage(error: $"Unknown provider '{provider}'. Valid: nessy, codex, qwen, cursor, windsurf, copilot, gemini, cline, aider, continue, roo, all");
 
     return await new AddProviderCommand(provider, force).ExecuteAsync();
 }
@@ -103,9 +103,9 @@ static int PrintUsage(string? error = null)
     Console.WriteLine("  new <project-name> [github-org]    Create a new multi-agent workspace");
     Console.WriteLine("    --provider <name>                 Provider: claude (default), nessy, codex, qwen,");
     Console.WriteLine("                                               cursor, windsurf, copilot, gemini,");
-    Console.WriteLine("                                               cline, aider, continue, all");
+    Console.WriteLine("                                               cline, roo, aider, continue, all");
     Console.WriteLine("  add-provider <name>                 Add a provider to an existing workspace");
-    Console.WriteLine("    <name>: nessy, codex, qwen, cursor, windsurf, copilot, gemini, cline, aider, continue, all");
+    Console.WriteLine("    <name>: nessy, codex, qwen, cursor, windsurf, copilot, gemini, cline, roo, aider, continue, all");
     Console.WriteLine("    --force                           Overwrite existing provider config");
     Console.WriteLine("  update                              Update workspace templates to latest version");
     Console.WriteLine("    --force                           Overwrite all files (CLAUDE.md preserved by default)");

--- a/tools/setup-cli/SetupCommand.cs
+++ b/tools/setup-cli/SetupCommand.cs
@@ -38,7 +38,7 @@ public sealed class SetupCommand(string projectName, string? requestedOrg, strin
         Console.WriteLine();
 
         var providers = provider == "all"
-            ? new[] { "claude", "codex", "qwen", "cursor", "windsurf", "copilot", "gemini", "cline", "aider", "continue" }
+            ? new[] { "claude", "codex", "qwen", "cursor", "windsurf", "copilot", "gemini", "cline", "aider", "continue", "roo" }
             : new[] { provider };
 
         CreateDirectories(targetDir, providers);
@@ -92,6 +92,8 @@ public sealed class SetupCommand(string projectName, string? requestedOrg, strin
             Console.WriteLine($"       aider         → run 'aider' from {targetDir}, CLAUDE.md loaded automatically");
         if (providers.Contains("continue"))
             Console.WriteLine($"       continue      → open {targetDir} in VS Code/JetBrains, rules load from .continue/config.yaml");
+        if (providers.Contains("roo"))
+            Console.WriteLine($"       roo           → open {targetDir} in VS Code with Roo Code extension, .roo/rules/ loads automatically");
         Console.WriteLine();
         return 0;
     }
@@ -104,7 +106,7 @@ public sealed class SetupCommand(string projectName, string? requestedOrg, strin
         ok &= Require("git", macOs: "brew install git",      win: "winget install Git.Git");
         ok &= Require("jq",  macOs: "brew install jq",       win: "winget install jqlang.jq");
         ok &= Require("gh",  macOs: "brew install gh",        win: "winget install GitHub.cli");
-        var providers = provider == "all" ? new[] { "claude", "codex", "qwen", "cursor", "windsurf", "copilot", "gemini", "cline", "aider", "continue" } : new[] { provider };
+        var providers = provider == "all" ? new[] { "claude", "codex", "qwen", "cursor", "windsurf", "copilot", "gemini", "cline", "aider", "continue", "roo" } : new[] { provider };
         if (providers.Contains("claude"))
             Suggest("claude",     "https://docs.anthropic.com/en/docs/claude-code");
         if (providers.Contains("nessy"))
@@ -127,6 +129,8 @@ public sealed class SetupCommand(string projectName, string? requestedOrg, strin
             Suggest("aider",      "https://aider.chat");
         if (providers.Contains("continue"))
             Console.WriteLine("  INFO: continue — VS Code/JetBrains extension, install from https://continue.dev");
+        if (providers.Contains("roo"))
+            Console.WriteLine("  INFO: roo — Roo Code VS Code extension, install from marketplace");
         Console.WriteLine();
         return ok;
     }
@@ -204,6 +208,8 @@ public sealed class SetupCommand(string projectName, string? requestedOrg, strin
             Directory.CreateDirectory(Path.Combine(root, ".gemini"));
         if (providers.Contains("continue"))
             Directory.CreateDirectory(Path.Combine(root, ".continue"));
+        if (providers.Contains("roo"))
+            Directory.CreateDirectory(Path.Combine(root, ".roo", "rules"));
         // cline and aider write files to workspace root — no subdirectory needed
     }
 
@@ -288,6 +294,9 @@ public sealed class SetupCommand(string projectName, string? requestedOrg, strin
 
         if (resourceName.StartsWith("providers/continue/"))
             return providers.Contains("continue") ? resourceName["providers/continue/".Length..] : null;
+
+        if (resourceName.StartsWith("providers/roo/"))
+            return providers.Contains("roo") ? resourceName["providers/roo/".Length..] : null;
 
         // Shared (CLAUDE.md, docs/, tools/)
         return resourceName;

--- a/tools/setup-cli/Templates/providers/roo/.roo/rules/workspace.md
+++ b/tools/setup-cli/Templates/providers/roo/.roo/rules/workspace.md
@@ -1,0 +1,76 @@
+# {{PROJECT_NAME}} — Multi-Agent Workspace
+
+{{PROJECT_DESCRIPTION}}
+
+**Founder:** {{FOUNDER}}. **Phase:** {{PHASE}}.
+
+---
+
+## How to start
+
+### Determine mode
+
+| Request type | What to do |
+|---|---|
+| Need full pipeline | Switch to **Orchestrator** mode → describe the task |
+| Need expert answer | Switch to **Architect** or **Code** mode → ask your question |
+| Quick question | Stay in current mode → ask directly |
+
+### Load context (all modes)
+
+- This file is auto-loaded by Roo Code from `.roo/rules/`
+- For code work: read `code/{{PROJECT_NAME}}/` (own CLAUDE.md inside)
+- For pipeline: read `docs/process.md` — operational manual
+
+---
+
+## Workspace structure
+
+```
+{{PROJECT_NAME}}/
+├── CLAUDE.md               ← workspace overview
+├── code/{{PROJECT_NAME}}/  ← main code repo
+├── docs/
+│   ├── process.md          ← pipeline rules (PLAN→BUILD→TEST→VERIFY→SHIP)
+│   ├── role-capabilities.md ← specialist roles index
+│   └── workflows/          ← workflow specs
+└── .roo/
+    └── rules/              ← Roo Code rules (this file)
+```
+
+## Orchestrator pipeline
+
+The `/orchestrator` command runs the full multi-agent pipeline:
+
+```
+PLAN → BUILD → TEST → VERIFY → SHIP
+```
+
+5 types: **feature** (full), **bugfix** (skip PLAN), **infra**, **content**, **spike** (PLAN only).
+
+Each step has a gate: `APPROVED` / `NEEDS WORK`. Retry: 3× → helper → 2× → CEO escalation.
+
+## Agent roles (specialist modes)
+
+Use these with Roo Code's custom modes or as prompts:
+
+| Domain | Role |
+|---|---|
+| Strategy | Product Manager, Trend Researcher |
+| Architecture | Software Architect, Backend Architect |
+| Engineering | Frontend Developer, Code Reviewer, DevOps, Security |
+| Design | UX Researcher, UI Designer |
+| GTM | Dev Advocate, Tech Writer, Marketing |
+
+Full capability index: `docs/role-capabilities.md`
+
+## Rules
+
+- **Code changes**: work only in `code/{{PROJECT_NAME}}/`
+- **Git**: `git status` before every commit; never `git init` in existing repo
+- **Confirm intent**: clarify ambiguous requests before acting
+- **Don't overengineer**: working solution > elegant solution
+
+## GitHub
+
+Backlog: `{{GITHUB_ORG}}/{{GITHUB_REPO}}`

--- a/tools/setup-cli/Templates/tools/completions.ps1
+++ b/tools/setup-cli/Templates/tools/completions.ps1
@@ -27,7 +27,7 @@ Register-ArgumentCompleter -Native -CommandName multiagent-setup -ScriptBlock {
     # Complete --provider values when previous token is --provider
     $prevToken = if ($tokens.Count -ge 2) { $tokens[-2].ToString() } else { "" }
     if ($prevToken -eq '--provider') {
-        @('claude', 'nessy', 'gemini', 'codex', 'qwen', 'cursor', 'windsurf', 'copilot', 'cline', 'aider', 'continue', 'all') |
+        @('claude', 'nessy', 'gemini', 'codex', 'qwen', 'cursor', 'windsurf', 'copilot', 'cline', 'aider', 'continue', 'roo', 'all') |
         Where-Object { $_ -like "$wordToComplete*" } | ForEach-Object {
             [System.Management.Automation.CompletionResult]::new($_, $_, 'ParameterValue', $_)
         }
@@ -43,7 +43,7 @@ Register-ArgumentCompleter -Native -CommandName multiagent-setup -ScriptBlock {
         }
         'add-provider' {
             if ($tokens.Count -eq 1 -or ($tokens.Count -eq 2 -and $wordToComplete)) {
-                @('claude', 'nessy', 'gemini', 'codex', 'qwen', 'cursor', 'windsurf', 'copilot', 'cline', 'aider', 'continue', 'all') | Where-Object { $_ -like "$wordToComplete*" } | ForEach-Object {
+                @('claude', 'nessy', 'gemini', 'codex', 'qwen', 'cursor', 'windsurf', 'copilot', 'cline', 'aider', 'continue', 'roo', 'all') | Where-Object { $_ -like "$wordToComplete*" } | ForEach-Object {
                     [System.Management.Automation.CompletionResult]::new($_, $_, 'ParameterValue', $_)
                 }
             } else {

--- a/tools/setup-cli/Templates/tools/completions.zsh
+++ b/tools/setup-cli/Templates/tools/completions.zsh
@@ -51,6 +51,7 @@ _multiagent_setup() {
     'cline:Cline extension for VS Code'
     'aider:Aider AI pair programmer'
     'continue:Continue.dev VS Code/JetBrains extension'
+    'roo:Roo Code VS Code extension'
     'all:All providers at once'
   )
   hooks=(


### PR DESCRIPTION
## Summary
- Adds `--provider roo` and `add-provider roo` support
- Generates `.roo/rules/workspace.md` — Roo Code reads rules from this directory automatically
- Distinct from Cline's `.clinerules` — Roo Code has its own rules format/location
- Included in `--provider all`
- Shell completions (zsh + PowerShell) updated

## Test plan
- [ ] `multiagent-setup new TestRoo --provider roo` creates `.roo/rules/workspace.md`
- [ ] `multiagent-setup add-provider roo` adds to existing workspace
- [ ] `--provider all` includes roo files
- [ ] `multiagent-setup -v` reports `1.20.0`