### PR TITLE
docs: add Roo Code to provider table, README, llms.txt — 12 providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,10 @@ multiagent-setup new MyProject --provider cursor     # Cursor IDE
 multiagent-setup new MyProject --provider windsurf   # Windsurf IDE
 multiagent-setup new MyProject --provider copilot    # GitHub Copilot
 multiagent-setup new MyProject --provider gemini     # Google Gemini CLI
-multiagent-setup new MyProject --provider cline      # Cline / Roo Code (VS Code)
+multiagent-setup new MyProject --provider cline      # Cline (VS Code)
 multiagent-setup new MyProject --provider aider      # Aider AI pair programmer
 multiagent-setup new MyProject --provider continue   # Continue.dev (VS Code / JetBrains)
+multiagent-setup new MyProject --provider roo        # Roo Code (VS Code)
 multiagent-setup new MyProject --provider all        # all providers at once
 
 # Add a provider to an existing workspace (no need to recreate)
@@ -102,11 +103,12 @@ Each step has an approval gate. Failures retry (3×) → helper role (2×) → h
 | **cursor** | [Cursor](https://cursor.com) IDE | IDE-first workflows | Rules in `.cursor/rules/` (MDC format) |
 | **windsurf** | [Windsurf](https://windsurf.com) IDE | IDE-first + Codeium users | Rules in `.windsurf/rules/` (Wave 8+) |
 | **copilot** | GitHub Copilot | VS Code + GitHub users | Reads `.github/copilot-instructions.md` |
-| **cline** | [Cline](https://github.com/cline/cline) / Roo Code | VS Code extension users | Creates `.clinerules` in project root |
+| **cline** | [Cline](https://github.com/cline/cline) | VS Code extension users | Creates `.clinerules` in project root |
 | **aider** | [Aider](https://aider.chat) | Terminal pair programming | Creates `.aider.conf.yml` — auto-reads CLAUDE.md |
 | **continue** | [Continue.dev](https://continue.dev) | VS Code + JetBrains users | `.continue/config.yaml` with `/orchestrator` slash command |
+| **roo** | [Roo Code](https://github.com/RooVetGit/Roo-Code) | VS Code extension users | Rules in `.roo/rules/` — auto-loaded per project |
 
-Use `--provider all` to scaffold all providers (claude + nessy + codex + qwen + cursor + windsurf + copilot + gemini + cline + aider + continue).
+Use `--provider all` to scaffold all providers (claude + nessy + codex + qwen + cursor + windsurf + copilot + gemini + cline + aider + continue + roo).
 
 ---
 
@@ -228,7 +230,7 @@ See [`examples/`](examples/) for concrete workflows:
 ## CLI Reference
 
 ```bash
-multiagent-setup new <project> [org] [--provider claude|nessy|codex|qwen|cursor|windsurf|copilot|gemini|cline|aider|continue|all]
+multiagent-setup new <project> [org] [--provider claude|nessy|codex|qwen|cursor|windsurf|copilot|gemini|cline|aider|continue|roo|all]
 multiagent-setup add-provider <provider> [--force]   # add provider to existing workspace
 multiagent-setup update [--force]                    # update workspace templates to latest version
 multiagent-setup sync-roles [--clone|--pull] [--agency-dir <path>]

--- a/README_RU.md
+++ b/README_RU.md
@@ -48,9 +48,10 @@ multiagent-setup new MyProject --provider qwen        # Qwen Code
 multiagent-setup new MyProject --provider cursor      # Cursor IDE
 multiagent-setup new MyProject --provider windsurf    # Windsurf IDE
 multiagent-setup new MyProject --provider copilot     # GitHub Copilot
-multiagent-setup new MyProject --provider cline       # Cline / Roo Code (VS Code)
+multiagent-setup new MyProject --provider cline       # Cline (VS Code)
 multiagent-setup new MyProject --provider aider       # Aider AI pair programmer
 multiagent-setup new MyProject --provider continue    # Continue.dev (VS Code / JetBrains)
+multiagent-setup new MyProject --provider roo         # Roo Code (VS Code)
 multiagent-setup new MyProject --provider all         # все провайдеры сразу
 
 # Добавить провайдер в существующий воркспейс
@@ -86,11 +87,12 @@ GitHub org определяется автоматически из `gh auth`. �
 | **cursor** | [Cursor](https://cursor.com) IDE | Правила в `.cursor/rules/` (MDC-формат) |
 | **windsurf** | [Windsurf](https://windsurf.com) IDE | Правила в `.windsurf/rules/` (Wave 8+) |
 | **copilot** | GitHub Copilot | Читает `.github/copilot-instructions.md` |
-| **cline** | [Cline](https://github.com/cline/cline) / Roo Code | Создаёт `.clinerules` в корне проекта |
+| **cline** | [Cline](https://github.com/cline/cline) | Создаёт `.clinerules` в корне проекта |
 | **aider** | [Aider](https://aider.chat) | Создаёт `.aider.conf.yml` — автозагружает CLAUDE.md |
 | **continue** | [Continue.dev](https://continue.dev) | VS Code / JetBrains; `.continue/config.yaml` с командой `/orchestrator` |
+| **roo** | [Roo Code](https://github.com/RooVetGit/Roo-Code) | Правила в `.roo/rules/` — автозагружаются по проекту |
 
-`--provider all` устанавливает все 11 провайдеров одновременно.
+`--provider all` устанавливает все 12 провайдеров одновременно.
 
 ---
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -49,7 +49,7 @@ multiagent-setup new <project-name> [github-org] [--provider <name>]
 
 Creates a workspace directory at `./project-name/`. Clones agency-agents and syncs roles globally to `~/.claude/commands/`. Initializes a git repo in the workspace.
 
-Providers: `claude` (default), `gemini`, `codex`, `qwen`, `cursor`, `windsurf`, `copilot`, `nessy`, `all`
+Providers: `claude` (default), `gemini`, `codex`, `qwen`, `cursor`, `windsurf`, `copilot`, `nessy`, `cline`, `aider`, `continue`, `roo`, `all`
 
 ### `sync-roles` — Update agent roles
 
@@ -69,7 +69,7 @@ multiagent-setup add-provider <provider> [--force]
 multiagent-setup add-provider all [--force]
 ```
 
-Adds a new provider's scaffold (config files, hooks, role commands) to an existing workspace without rebuilding from scratch. Use `all` to add every provider at once (nessy, codex, qwen, cursor, windsurf, copilot, gemini, cline, aider, continue).
+Adds a new provider's scaffold (config files, hooks, role commands) to an existing workspace without rebuilding from scratch. Use `all` to add every provider at once (nessy, codex, qwen, cursor, windsurf, copilot, gemini, cline, aider, continue, roo).
 
 ### `update` — Update workspace templates to latest version
 
@@ -122,6 +122,10 @@ Runs a compiled safety hook. All hooks are baked into the binary (no shell scrip
 | `cursor` | Cursor | `.cursor/rules/workspace.mdc` (alwaysApply: true) | `.cursor/rules/workspace.mdc` |
 | `windsurf` | Windsurf | `.windsurf/rules/workspace.md` | `.windsurf/rules/workspace.md` |
 | `copilot` | VS Code + GitHub Copilot | `.github/copilot-instructions.md` | `.github/copilot-instructions.md` |
+| `cline` | VS Code Cline extension | `.clinerules` (project root) | `.clinerules` |
+| `aider` | Aider (terminal) | `.aider.conf.yml` | `CLAUDE.md` (auto-read) |
+| `continue` | VS Code/JetBrains Continue | `.continue/config.yaml` | `.continue/config.yaml` |
+| `roo` | VS Code Roo Code extension | `.roo/rules/workspace.md` | `.roo/rules/workspace.md` |
 
 ## Pipeline System
 

--- a/llms.txt
+++ b/llms.txt
@@ -33,9 +33,10 @@ multiagent-setup new MyProject
 - **Cursor** (`cursor`) — Cursor IDE; rules injected via `.cursor/rules/` (MDC format)
 - **Windsurf** (`windsurf`) — Windsurf IDE by Codeium; rules via `.windsurf/rules/`
 - **Copilot** (`copilot`) — GitHub Copilot in VS Code; instructions via `.github/copilot-instructions.md`
-- **Cline** (`cline`) — Cline and Roo Code VS Code extension; rules via `.clinerules`
+- **Cline** (`cline`) — Cline VS Code extension; rules via `.clinerules`
 - **Aider** (`aider`) — Aider AI pair programmer; config via `.aider.conf.yml` (auto-reads CLAUDE.md)
 - **Continue.dev** (`continue`) — VS Code/JetBrains extension; config via `.continue/config.yaml` with `/orchestrator` slash command
+- **Roo Code** (`roo`) — Roo Code VS Code extension; rules auto-loaded from `.roo/rules/`
 
 Use `--provider all` to scaffold all providers at once, `add-provider <name>` (or `add-provider all`) to add providers to an existing workspace, or `update` to pull the latest templates into an existing workspace.
 


### PR DESCRIPTION
## Summary
- Add Roo Code row to provider tables in README.md, README_RU.md
- Add `--provider roo` to Quick Start code blocks
- Update `--provider all` description to mention all 12 providers
- Update llms.txt and llms-full.txt with Roo Code entry
- gh-pages: add Roo Code card, update badge from 11→12

## Follows
- v1.20.0 (feat: add Roo Code provider) — #75