### PR TITLE
fix(dx): DX, features, docs, and SEO improvements — #82-#113

### DIFF
--- a/.claude/mcp.json
+++ b/.claude/mcp.json
@@ -1,3 +1,19 @@
 {
-  "mcpServers": {}
+  "mcpServers": {
+    "age-mcp": {
+      "type": "stdio",
+      "command": "age-mcp",
+      "env": {
+        "AGE_CONNECTION_STRING": "Host=localhost;Port=5435;Database=agemcp;Username=agemcp;Password=agemcp",
+        "TENANT_ID": "default"
+      }
+    },
+    "o-brien": {
+      "type": "stdio",
+      "command": "obrien-mcp",
+      "env": {
+        "DATABASE_URL": "Host=localhost;Port=5433;Database=obrien;Username=postgres;Password=postgres"
+      }
+    }
+  }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Version
 
 ---
 
+## [1.33.0] — 2026-04-09
+
+### Added
+- **`completions` subcommand** — `multiagent-setup completions zsh` and `multiagent-setup completions pwsh` print the shell completion script to stdout. Install with `eval "$(multiagent-setup completions zsh)"` or append to `~/.zshrc` / `$PROFILE`. No longer requires locating the file in a scaffolded workspace.
+- **`--dry-run` for `update`** — preview which files would be created or overwritten without writing anything. Works with and without `--force`.
+- **`--dry-run` for `remove-provider`** — preview which directories and files would be deleted without making any changes. Skips the confirmation prompt in dry-run mode.
+- **Shell completions updated** — `completions.zsh` and `completions.ps1` now cover all commands (`init`, `remove-provider`, `list-providers`, `completions`), all flags (`--dry-run`, `--global`, `--template`, `--for`), all 13 providers (added `kiro`), and all templates (`default`, `saas`, `oss`, `internal`).
+
+---
+
 ## [1.32.0] — 2026-04-09
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,33 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Version
 
 ---
 
+## [1.32.0] — 2026-04-09
+
+### Added
+- **Workspace templates** (`--template saas|oss|internal|default`) — `new` and `init` now accept `--template` to scaffold a `process.md` tuned for the project type. `saas`: user-impact VERIFY gates, feature flags, analytics events, SLO review, canary deploy guidance. `oss`: CHANGELOG required in SHIP, semver gates, backward-compat escalation, contributor guidelines, security disclosure process. `internal`: simplified pipeline with skippable PLAN/VERIFY for small tasks.
+- **Gemini CLI extension sync** — `sync-roles` now syncs roles to `~/.gemini/extensions/agency-agents/` as TOML commands when a `.gemini/` workspace is detected or `--global` is specified.
+- **`doctor --for <command>` pre-flight mode** — targeted health check before running `sync-roles`, `init`, or `update`. Exits 1 if prerequisites aren't met.
+- **`init` command** — `multiagent-setup init [dir]` injects workspace files into any existing git repository without creating a new directory. Supports `--provider`, `--template`, `--force`.
+- **`list-providers` command** — shows installed vs. available providers with their workspace instructions files.
+- **`remove-provider` command** — cleanly removes a provider's files from an existing workspace.
+- **`sync-roles --global`** — syncs roles to `~/.claude/commands/` globally in addition to the local workspace.
+- **`bootstrap.ps1` init mode** — now detects when the first argument is a path or existing directory and uses `multiagent-setup init` instead of `new`, matching `bootstrap.sh` behavior.
+
+### Fixed
+- `sync-roles`, `install-mcps`, and `hook` now respect `--help`/`-h` and show usage instead of executing.
+- `hook --help` now shows the full usage including the `research-reminder` hook.
+- README duplicate Contributing section removed.
+- Docs updated: `--template`, `--target`, `--for`, `init` command signatures added to README, llms-full.txt, and llms.txt.
+
+---
+
+## [1.31.0] — 2026-04-09
+
+### Added
+- **Homebrew formula updated to v1.31.0** — SHA256 checksums for osx-arm64, osx-x64, linux-x64 binaries.
+
+---
+
 ## [1.30.0] — 2026-04-09
 
 ### Fixed

--- a/Formula/multiagent-setup.rb
+++ b/Formula/multiagent-setup.rb
@@ -2,21 +2,21 @@ class MultiagentSetup < Formula
   desc "Scaffold autonomous multi-agent AI workspaces for 12 AI coding assistants"
   homepage "https://github.com/Neftedollar/multiagent-template"
   license "MIT"
-  version "1.30.0"
+  version "1.31.0"
 
   on_macos do
     if Hardware::CPU.arm?
-      url "https://github.com/Neftedollar/multiagent-template/releases/download/v1.30.0/multiagent-setup-1.30.0-osx-arm64.tar.gz"
-      sha256 "f9438ad6003a6a0f4e57fbb9f9429307a564b95f793745b92fd9271ae45e00fe"
+      url "https://github.com/Neftedollar/multiagent-template/releases/download/v1.31.0/multiagent-setup-1.31.0-osx-arm64.tar.gz"
+      sha256 "f2dc80e35436de4801f0a6ae1e150bc2fb16a4764d60f96b6b3930e531b0f2f3"
     else
-      url "https://github.com/Neftedollar/multiagent-template/releases/download/v1.30.0/multiagent-setup-1.30.0-osx-x64.tar.gz"
-      sha256 "a031aa050b0f874ddc7c587ff73dbd8e0a492ded8779ef2000b99ebdee8087ba"
+      url "https://github.com/Neftedollar/multiagent-template/releases/download/v1.31.0/multiagent-setup-1.31.0-osx-x64.tar.gz"
+      sha256 "bd7e4bbe73f4beb03c489680a896365ce470e1e3a0f55526f5cf7789efd8bc58"
     end
   end
 
   on_linux do
-    url "https://github.com/Neftedollar/multiagent-template/releases/download/v1.30.0/multiagent-setup-1.30.0-linux-x64.tar.gz"
-    sha256 "90aa211e4c9e35c930caf6863d9a405d323ce938a18075c2a350d72e6e64bc2a"
+    url "https://github.com/Neftedollar/multiagent-template/releases/download/v1.31.0/multiagent-setup-1.31.0-linux-x64.tar.gz"
+    sha256 "c43e991a82c1019b1d7706cdfa2d40527b0dcb753cbb17b19aa7611a2744b37b"
   end
 
   def install

--- a/Formula/multiagent-setup.rb
+++ b/Formula/multiagent-setup.rb
@@ -1,5 +1,5 @@
 class MultiagentSetup < Formula
-  desc "Scaffold autonomous multi-agent AI workspaces for 12 AI coding assistants"
+  desc "Scaffold autonomous multi-agent AI workspaces for 13 AI coding assistants"
   homepage "https://github.com/Neftedollar/multiagent-template"
   license "MIT"
   version "1.31.0"

--- a/README.md
+++ b/README.md
@@ -64,9 +64,15 @@ multiagent-setup new MyProject --provider continue   # Continue.dev (VS Code / J
 multiagent-setup new MyProject --provider roo        # Roo Code (VS Code)
 multiagent-setup new MyProject --provider all        # all providers at once
 
+# Choose a workspace template (saas, oss, internal, or default)
+multiagent-setup new MyProject --template saas       # SaaS product (user-impact gates, feature flags, SLO review)
+multiagent-setup new MyProject --template oss        # Open source (CHANGELOG, semver, backward-compat gates)
+multiagent-setup new MyProject --template internal   # Internal tools (lighter pipeline, no external gates)
+
 # Add workspace files to an existing git repo (does not touch your code)
 multiagent-setup init .                              # current directory
 multiagent-setup init ./my-repo                      # specific directory
+multiagent-setup init . --template saas              # with template
 
 # Add a provider to an existing workspace (no need to recreate)
 multiagent-setup add-provider cursor
@@ -323,6 +329,10 @@ multiagent-setup -v | --version
 
 Templates live in [`tools/setup-cli/Templates/`](tools/setup-cli/Templates/). Each provider gets its own directory under `providers/`. See [CONTRIBUTING.md](CONTRIBUTING.md) for setup instructions and how to add a new provider.
 
+Questions and ideas → [Discussions](https://github.com/Neftedollar/multiagent-template/discussions).
+
+If this saves you time, a ⭐ star helps others find it.
+
 ---
 
 ## FAQ
@@ -359,14 +369,6 @@ Yes. A GitHub Actions workflow (`orchestrator.yml`) is scaffolded for claude/nes
 
 **Does the pipeline need internet access?**  
 Only for git push/PR creation steps and any web research the agent does. All local code analysis, formatting, and linting runs offline.
-
----
-
-## Contributing
-
-See [CONTRIBUTING.md](CONTRIBUTING.md). Questions and ideas → [Discussions](https://github.com/Neftedollar/multiagent-template/discussions).
-
-If this saves you time, a ⭐ star helps others find it.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # multiagent-template — Multi-Agent AI Orchestration for Autonomous Code Generation
 
-**Autonomous multi-agent code generation and PR automation for 12 AI coding assistants.** Scaffold a structured workspace where specialized agents (orchestrator, architect, developer, reviewer, DevOps, designer) operate in a gated pipeline (PLAN → BUILD → TEST → VERIFY → SHIP) to drive software from backlog to merged PR autonomously — without context collapse, without code review bottlenecks, without hand-holding. You set direction; the agents handle execution.
+**Autonomous multi-agent code generation and PR automation for 13 AI coding assistants.** Scaffold a structured workspace where specialized agents (orchestrator, architect, developer, reviewer, DevOps, designer) operate in a gated pipeline (PLAN → BUILD → TEST → VERIFY → SHIP) to drive software from backlog to merged PR autonomously — without context collapse, without code review bottlenecks, without hand-holding. You set direction; the agents handle execution.
 
 [![NuGet](https://img.shields.io/nuget/v/multiagent-setup)](https://www.nuget.org/packages/multiagent-setup)
 [![Build](https://github.com/Neftedollar/multiagent-template/actions/workflows/build.yml/badge.svg)](https://github.com/Neftedollar/multiagent-template/actions/workflows/build.yml)
@@ -188,6 +188,64 @@ One human (CEO) gives tasks. The **Orchestrator** agent breaks them into steps, 
 | **CEO Mode** | `/orchestrator <task>` | Human gives task, orchestrator executes |
 | **Single Expert** | `/<role> <question>` | Direct expert call, no pipeline |
 | **Autonomous** | `claude -p "/orchestrator ..."` | Orchestrator self-selects tasks from backlog |
+
+### Using IDE providers (Cursor, Windsurf, Copilot, Cline, Continue, Roo, Kiro)
+
+After `multiagent-setup new MyProject --provider cursor` (or any IDE provider):
+
+1. **Open the workspace in your IDE** — open the `MyProject/` directory (not a subdirectory)
+2. **Invoke the orchestrator** — use your IDE's AI chat panel and type `/orchestrator <task>`:
+   - Cursor: `Cmd+K` or `Cmd+L` chat panel → `/orchestrator Implement user authentication`
+   - Windsurf: Cascade panel → `/orchestrator ...`
+   - Copilot: GitHub Copilot Chat → `@workspace /orchestrator ...`
+   - Cline: Cline panel → `/orchestrator ...`
+   - Continue / Roo / Kiro: respective chat panel → `/orchestrator ...`
+
+3. **Slash commands are pre-loaded** — `.cursor/rules/orchestrator.mdc` (and equivalent for each provider) is scaffolded with `alwaysApply: true`, so the orchestrator role is active automatically. All 20+ specialist roles are in `.claude/commands/` and invokable as slash commands.
+
+4. **Hooks require the CLI on PATH** — safety hooks (`block-dangerous`, `auto-lint`, etc.) are compiled into the `multiagent-setup` binary. IDE agents don't run hooks unless the binary is on PATH and the IDE inherits the shell environment. Terminal providers (Claude, Codex, Gemini, etc.) get hooks automatically via `.claude/settings.json`.
+
+5. **The pipeline is the same** — `PLAN → BUILD → TEST → VERIFY → SHIP` works identically whether you're using a terminal agent or an IDE agent. Gate approvals appear as responses in the chat panel.
+
+### Autonomous mode — setting up the backlog
+
+To run the orchestrator fully headlessly (no human in the loop):
+
+**1. Create a GitHub Project**
+
+Go to your GitHub repo → Projects → New project. Use the "Board" template with columns: `Backlog`, `In Progress`, `Done`. Link the project to your repository.
+
+**2. Add issues to Backlog**
+
+Write issues as tasks for the orchestrator. Good format:
+```
+Title: Implement user authentication with JWT
+Body: 
+- Users can sign up with email/password
+- JWT tokens expire in 7 days
+- Refresh token flow included
+- Acceptance: all auth endpoints have integration tests
+```
+
+**3. Trigger autonomously**
+
+```bash
+# One-shot: pick one task from backlog and implement it
+claude -p "/orchestrator Pick the highest-priority task from the GitHub Project backlog and implement it."
+
+# Or use the GitHub Actions CI workflow (label an issue with 'orchestrator')
+# The scaffolded .github/workflows/orchestrator.yml triggers automatically
+```
+
+The `orchestrator.yml` CI workflow triggers when you add the `orchestrator` label to any issue. It runs headlessly, implements the task, and opens a PR. You review and merge.
+
+**4. Loop mode** (drain the whole backlog unattended)
+
+```bash
+claude -p "/orchestrator Pick tasks from the GitHub Project backlog. Implement each one. Create a PR per task. Stop when the backlog is empty."
+```
+
+> The `CLAUDE.md` template variables `{{GITHUB_ORG}}` and `{{GITHUB_REPO}}` are substituted at workspace creation time with your actual org/repo names — no manual editing needed.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ multiagent-setup new MyProject --provider cline      # Cline (VS Code)
 multiagent-setup new MyProject --provider aider      # Aider AI pair programmer
 multiagent-setup new MyProject --provider continue   # Continue.dev (VS Code / JetBrains)
 multiagent-setup new MyProject --provider roo        # Roo Code (VS Code)
+multiagent-setup new MyProject --provider kiro       # Amazon Kiro (VS Code)
 multiagent-setup new MyProject --provider all        # all providers at once
 
 # Choose a workspace template (saas, oss, internal, or default)
@@ -140,7 +141,7 @@ Each step has an approval gate. Failures retry (3×) → helper role (2×) → h
 | Team of specialized roles | ✅ | ❌ | ❌ |
 | Autonomous overnight backlog drain | ✅ | Limited | ❌ |
 | Works inside your existing IDE | ✅ (via provider flags) | ✅ | ✅ |
-| Any AI provider (Claude, Gemini, Codex…) | ✅ 12 providers | Claude only | Any, but no pipeline |
+| Any AI provider (Claude, Gemini, Codex…) | ✅ 13 providers | Claude only | Any, but no pipeline |
 
 ---
 
@@ -160,8 +161,9 @@ Each step has an approval gate. Failures retry (3×) → helper role (2×) → h
 | **aider** | [Aider](https://aider.chat) | Terminal pair programming | Creates `.aider.conf.yml` — auto-reads CLAUDE.md |
 | **continue** | [Continue.dev](https://continue.dev) | VS Code + JetBrains users | `.continue/config.yaml` with `/orchestrator` slash command |
 | **roo** | [Roo Code](https://github.com/RooVetGit/Roo-Code) | VS Code extension users | Rules in `.roo/rules/` — auto-loaded per project |
+| **kiro** | [Amazon Kiro](https://kiro.dev) | AWS + VS Code users | Steering docs in `.kiro/steering/` — auto-loaded by Kiro |
 
-Use `--provider all` to scaffold all providers (claude + nessy + codex + qwen + cursor + windsurf + copilot + gemini + cline + aider + continue + roo).
+Use `--provider all` to scaffold all providers (claude + nessy + codex + qwen + cursor + windsurf + copilot + gemini + cline + aider + continue + roo + kiro).
 
 ---
 
@@ -296,7 +298,7 @@ See [`examples/`](examples/) for concrete workflows:
 ## CLI Reference
 
 ```bash
-multiagent-setup new <project> [org] [--provider claude|nessy|codex|qwen|cursor|windsurf|copilot|gemini|cline|aider|continue|roo|all] [--template default|saas|oss|internal]
+multiagent-setup new <project> [org] [--provider claude|nessy|codex|qwen|cursor|windsurf|copilot|gemini|cline|aider|continue|roo|kiro|all] [--template default|saas|oss|internal]
 multiagent-setup init [dir] [--provider <name>] [--template <name>] [--force]   # add workspace to existing repo
 multiagent-setup add-provider <provider> [--force]            # add provider to existing workspace
 multiagent-setup remove-provider <provider> [--force]         # remove a provider and its files

--- a/README.md
+++ b/README.md
@@ -301,13 +301,14 @@ See [`examples/`](examples/) for concrete workflows:
 multiagent-setup new <project> [org] [--provider claude|nessy|codex|qwen|cursor|windsurf|copilot|gemini|cline|aider|continue|roo|kiro|all] [--template default|saas|oss|internal]
 multiagent-setup init [dir] [--provider <name>] [--template <name>] [--force]   # add workspace to existing repo
 multiagent-setup add-provider <provider> [--force]            # add provider to existing workspace
-multiagent-setup remove-provider <provider> [--force]         # remove a provider and its files
-multiagent-setup list-providers                               # list installed and available providers
-multiagent-setup update [--force]                             # update workspace templates to latest version
+multiagent-setup remove-provider <provider> [--force] [--dry-run]  # remove a provider (--dry-run to preview)
+multiagent-setup list-providers                                    # list installed and available providers
+multiagent-setup update [--force] [--dry-run]                      # update templates (--dry-run to preview)
 multiagent-setup sync-roles [--clone|--pull] [--global] [--agency-dir <path>]
 multiagent-setup install-mcps [--docker|--manual] [--age-conn <str>] [--obrien-conn <str>] [--target <dir>]
 multiagent-setup hook <name>
-multiagent-setup doctor [--for sync-roles|init|update]       # check workspace or run pre-flight check
+multiagent-setup doctor [--for sync-roles|init|update]             # check workspace or run pre-flight check
+multiagent-setup completions zsh|pwsh                              # print shell completion script
 multiagent-setup -v | --version
 ```
 

--- a/README.md
+++ b/README.md
@@ -16,11 +16,19 @@
 
 ## Quick Start
 
+**Which command do I need?**
+
+| Situation | Command |
+|-----------|---------|
+| Starting a new project | `multiagent-setup new <name>` |
+| Adding to an existing git repo | `multiagent-setup init .` |
+
 **macOS — Homebrew (no .NET required):**
 
 ```bash
 brew install Neftedollar/multiagent-template/multiagent-setup
-multiagent-setup new MyProject
+multiagent-setup new MyProject          # new workspace
+multiagent-setup init .                 # add to existing repo
 ```
 
 **One-liner bootstrap** (installs all deps including Homebrew/winget, agent CLI, and creates the workspace):
@@ -54,6 +62,10 @@ multiagent-setup new MyProject --provider continue   # Continue.dev (VS Code / J
 multiagent-setup new MyProject --provider roo        # Roo Code (VS Code)
 multiagent-setup new MyProject --provider all        # all providers at once
 
+# Add workspace files to an existing git repo (does not touch your code)
+multiagent-setup init .                              # current directory
+multiagent-setup init ./my-repo                      # specific directory
+
 # Add a provider to an existing workspace (no need to recreate)
 multiagent-setup add-provider cursor
 multiagent-setup add-provider gemini --force   # overwrite existing files
@@ -72,6 +84,15 @@ claude          # or: nessy / codex / qwen-code / gemini (terminal agents)
                 # or open in Cursor / Windsurf / VS Code (IDE agents)
 /orchestrator Implement user authentication with JWT
 ```
+
+**What happens next:**
+1. Orchestrator reads `docs/process.md` and selects roles dynamically
+2. Creates a plan and asks: `APPROVED / NEEDS WORK?`
+3. Proceeds through **BUILD → TEST → VERIFY → SHIP**
+4. Opens a PR on GitHub when done — no manual intervention needed
+
+> Interactive mode: Claude asks for gate approval at each step.  
+> Autonomous mode (`claude -p`): runs fully headless, escalates blockers to GitHub Issues.
 
 **What you get in 5 minutes:**
 - A workspace where agents run `PLAN → BUILD → TEST → VERIFY → SHIP` autonomously
@@ -181,6 +202,17 @@ MyProject/
     └── completions.ps1      <- PowerShell completions
 ```
 
+### Two CLAUDE.md files
+
+The workspace uses two separate instruction files:
+
+| File | Purpose |
+|------|---------|
+| `CLAUDE.md` (workspace root) | **How Claude operates** — pipeline, roles, process, team structure |
+| `code/<project>/CLAUDE.md` | **What Claude builds** — architecture, patterns, build commands, test setup |
+
+When you clone your code repo into `code/<project>/`, create a `CLAUDE.md` there describing the codebase (or copy your existing one). Claude Code automatically reads both files.
+
 **Bringing in an existing codebase:**
 
 ```bash
@@ -253,6 +285,7 @@ See [`examples/`](examples/) for concrete workflows:
 
 ```bash
 multiagent-setup new <project> [org] [--provider claude|nessy|codex|qwen|cursor|windsurf|copilot|gemini|cline|aider|continue|roo|all]
+multiagent-setup init [dir] [--provider <name>] [--force]  # add workspace files to an existing git repo
 multiagent-setup add-provider <provider> [--force]   # add provider to existing workspace
 multiagent-setup update [--force]                    # update workspace templates to latest version
 multiagent-setup sync-roles [--clone|--pull] [--agency-dir <path>]
@@ -287,7 +320,7 @@ Templates live in [`tools/setup-cli/Templates/`](tools/setup-cli/Templates/). Ea
 ## FAQ
 
 **Does this work with projects that already have code?**  
-Yes. The workspace wraps your existing repo: `multiagent-setup new MyProject` creates the workspace, then clone your repo into `code/MyProject/`.
+Yes — two options: (1) run `multiagent-setup init .` inside your existing repo to add workspace files directly, or (2) run `multiagent-setup new MyProject` to create a separate workspace, then clone your repo into `code/MyProject/`.
 
 **How do I use multiple providers?**  
 Run `multiagent-setup new MyProject --provider all` to scaffold all providers at once. To add a provider to an existing workspace: `multiagent-setup add-provider gemini`.

--- a/README.md
+++ b/README.md
@@ -296,16 +296,16 @@ See [`examples/`](examples/) for concrete workflows:
 ## CLI Reference
 
 ```bash
-multiagent-setup new <project> [org] [--provider claude|nessy|codex|qwen|cursor|windsurf|copilot|gemini|cline|aider|continue|roo|all]
-multiagent-setup init [dir] [--provider <name>] [--force]    # add workspace files to an existing git repo
+multiagent-setup new <project> [org] [--provider claude|nessy|codex|qwen|cursor|windsurf|copilot|gemini|cline|aider|continue|roo|all] [--template default|saas|oss|internal]
+multiagent-setup init [dir] [--provider <name>] [--template <name>] [--force]   # add workspace to existing repo
 multiagent-setup add-provider <provider> [--force]            # add provider to existing workspace
 multiagent-setup remove-provider <provider> [--force]         # remove a provider and its files
 multiagent-setup list-providers                               # list installed and available providers
 multiagent-setup update [--force]                             # update workspace templates to latest version
 multiagent-setup sync-roles [--clone|--pull] [--global] [--agency-dir <path>]
-multiagent-setup install-mcps [--docker|--manual] [--age-conn <str>] [--obrien-conn <str>]
+multiagent-setup install-mcps [--docker|--manual] [--age-conn <str>] [--obrien-conn <str>] [--target <dir>]
 multiagent-setup hook <name>
-multiagent-setup doctor                                       # check workspace for common config issues
+multiagent-setup doctor [--for sync-roles|init|update]       # check workspace or run pre-flight check
 multiagent-setup -v | --version
 ```
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,10 @@ multiagent-setup add-provider cursor
 multiagent-setup add-provider gemini --force   # overwrite existing files
 multiagent-setup add-provider all              # add all providers at once
 
+# Manage providers
+multiagent-setup list-providers               # show installed vs. available providers
+multiagent-setup remove-provider cursor       # cleanly remove a provider and its files
+
 # Update an existing workspace to the latest templates
 multiagent-setup update          # skip already-customised files
 multiagent-setup update --force  # overwrite everything (CLAUDE.md preserved)
@@ -285,13 +289,15 @@ See [`examples/`](examples/) for concrete workflows:
 
 ```bash
 multiagent-setup new <project> [org] [--provider claude|nessy|codex|qwen|cursor|windsurf|copilot|gemini|cline|aider|continue|roo|all]
-multiagent-setup init [dir] [--provider <name>] [--force]  # add workspace files to an existing git repo
-multiagent-setup add-provider <provider> [--force]   # add provider to existing workspace
-multiagent-setup update [--force]                    # update workspace templates to latest version
-multiagent-setup sync-roles [--clone|--pull] [--agency-dir <path>]
+multiagent-setup init [dir] [--provider <name>] [--force]    # add workspace files to an existing git repo
+multiagent-setup add-provider <provider> [--force]            # add provider to existing workspace
+multiagent-setup remove-provider <provider> [--force]         # remove a provider and its files
+multiagent-setup list-providers                               # list installed and available providers
+multiagent-setup update [--force]                             # update workspace templates to latest version
+multiagent-setup sync-roles [--clone|--pull] [--global] [--agency-dir <path>]
 multiagent-setup install-mcps [--docker|--manual] [--age-conn <str>] [--obrien-conn <str>]
 multiagent-setup hook <name>
-multiagent-setup doctor                              # check workspace for common config issues
+multiagent-setup doctor                                       # check workspace for common config issues
 multiagent-setup -v | --version
 ```
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ claude          # or: nessy / codex / qwen-code / gemini (terminal agents)
 **What happens next:**
 1. Orchestrator reads `docs/process.md` and selects roles dynamically
 2. Creates a plan and asks: `APPROVED / NEEDS WORK?`
-3. Proceeds through **BUILD → TEST → VERIFY → SHIP**
+3. Proceeds through **PLAN → BUILD → TEST → VERIFY → SHIP**
 4. Opens a PR on GitHub when done — no manual intervention needed
 
 > Interactive mode: Claude asks for gate approval at each step.  

--- a/README.md
+++ b/README.md
@@ -1,12 +1,14 @@
-# multiagent-template
+# multiagent-template — Multi-Agent AI Orchestration for Autonomous Code Generation
 
-**Autonomous multi-agent code generation and PR automation for 12 AI coding assistants.** Scaffold a workspace where a team of specialized agents — orchestrator, architect, developer, reviewer, DevOps, designer, and more — drives software from backlog to merged PR without hand-holding. You set direction; the agents handle execution.
+**Autonomous multi-agent code generation and PR automation for 12 AI coding assistants.** Scaffold a structured workspace where specialized agents (orchestrator, architect, developer, reviewer, DevOps, designer) operate in a gated pipeline (PLAN → BUILD → TEST → VERIFY → SHIP) to drive software from backlog to merged PR autonomously — without context collapse, without code review bottlenecks, without hand-holding. You set direction; the agents handle execution.
 
 [![NuGet](https://img.shields.io/nuget/v/multiagent-setup)](https://www.nuget.org/packages/multiagent-setup)
 [![Build](https://github.com/Neftedollar/multiagent-template/actions/workflows/build.yml/badge.svg)](https://github.com/Neftedollar/multiagent-template/actions/workflows/build.yml)
 [![GitHub stars](https://img.shields.io/github/stars/Neftedollar/multiagent-template?style=social)](https://github.com/Neftedollar/multiagent-template/stargazers)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Discussions](https://img.shields.io/badge/Discussions-join-blue)](https://github.com/Neftedollar/multiagent-template/discussions)
+
+**Tags:** AI agent orchestration · multi-agent AI · autonomous code generation · Claude Code · AI workflow automation · code review pipeline · agent routing · multi-LLM support · Claude Sonnet · OpenAI Codex · Gemini CLI
 
 <p align="center">
   <img src="docs/demo.svg" alt="multiagent-setup demo" width="720"/>

--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -129,6 +129,9 @@ if (-not $installed) {
 
 # Build argument list based on mode
 if ($_Mode -eq "init") {
+    if ($GithubOrg) {
+        Write-Warning "GithubOrg ('$GithubOrg') is ignored in init mode — org is inferred from the repo's git remote."
+    }
     $argList = @("init", $_Target)
     if ($Provider) { $argList += "--provider"; $argList += $Provider }
 } else {

--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -3,9 +3,11 @@
 #
 # Usage:
 #   irm https://raw.githubusercontent.com/Neftedollar/multiagent-template/main/bootstrap.ps1 -OutFile bootstrap.ps1
-#   .\bootstrap.ps1 MyProject
-#   .\bootstrap.ps1 MyProject --provider gemini
-#   .\bootstrap.ps1 MyProject my-org --provider all
+#   .\bootstrap.ps1 MyProject                        # create new workspace
+#   .\bootstrap.ps1 MyProject --provider gemini      # with specific provider
+#   .\bootstrap.ps1 MyProject my-org --provider all  # with GitHub org
+#   .\bootstrap.ps1 .                                # inject into current git repo (init mode)
+#   .\bootstrap.ps1 C:\path\to\repo                  # inject into existing git repo (init mode)
 param(
     [Parameter(Position=0, Mandatory=$true)][string]$ProjectName,
     [Parameter(Position=1)][string]$GithubOrg = "",
@@ -27,9 +29,22 @@ function Install-WinGet([string]$Id, [string]$Name) {
     RefreshPath
 }
 
+# Detect init vs new mode:
+# init mode — arg is ".", an absolute path, a relative .\ path, or an existing directory
+# new mode  — arg is a plain project name (no path separators)
+$isPath = ($ProjectName -eq ".") -or
+          ($ProjectName -match '^[A-Za-z]:\\') -or
+          ($ProjectName -match '^\\\\') -or
+          ($ProjectName -match '^\.\\') -or
+          ($ProjectName -match '^\.\.\\') -or
+          (Test-Path $ProjectName -PathType Container)
+$_Mode = if ($isPath) { "init" } else { "new" }
+$_Target = if ($isPath) { (Resolve-Path $ProjectName -ErrorAction SilentlyContinue).Path ?? $ProjectName } else { $ProjectName }
+
 Write-Host "============================================"
 Write-Host "  Multi-Agent Workspace Bootstrap"
-Write-Host "  Project:  $ProjectName"
+Write-Host "  Mode:     $_Mode"
+Write-Host "  Target:   $_Target"
 Write-Host "  Provider: $(if ($Provider) { $Provider } else { 'claude (default)' })"
 Write-Host "  OS:       Windows"
 Write-Host "============================================"
@@ -112,9 +127,15 @@ if (-not $installed) {
     & dotnet tool update -g multiagent-setup 2>&1 | Out-Null
 }
 
-$argList = @("new", $ProjectName)
-if ($GithubOrg)  { $argList += $GithubOrg }
-if ($Provider)   { $argList += "--provider"; $argList += $Provider }
+# Build argument list based on mode
+if ($_Mode -eq "init") {
+    $argList = @("init", $_Target)
+    if ($Provider) { $argList += "--provider"; $argList += $Provider }
+} else {
+    $argList = @("new", $ProjectName)
+    if ($GithubOrg) { $argList += $GithubOrg }
+    if ($Provider)  { $argList += "--provider"; $argList += $Provider }
+}
 
 & multiagent-setup @argList
 exit $LASTEXITCODE

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -154,65 +154,76 @@ if has multiagent-setup; then
   else
     echo "  ..  Updating multiagent-setup $_ms_installed → $MULTIAGENT_VERSION..."
     if [ "$OS" = "Darwin" ] && has brew; then
-      brew upgrade Neftedollar/multiagent-template/multiagent-setup 2>/dev/null \
+      brew upgrade Neftedollar/multiagent-template/multiagent-setup \
         || brew reinstall Neftedollar/multiagent-template/multiagent-setup
     else
       dotnet tool update -g multiagent-setup
-      # Persist .dotnet/tools to PATH in shell rc (Linux only)
-      if [[ "$OS" != "Darwin" ]]; then
-        _dotnet_line='export PATH="$HOME/.dotnet:$HOME/.dotnet/tools:$PATH"'
-        _added=false
-        for _rc in "$HOME/.zshrc" "$HOME/.bashrc" "$HOME/.profile"; do
-          if [[ -f "$_rc" ]] && ! grep -q '\.dotnet' "$_rc" 2>/dev/null; then
-            echo "" >> "$_rc"
-            echo "# multiagent-setup: .NET tools path" >> "$_rc"
-            echo "$_dotnet_line" >> "$_rc"
-            echo "  INFO: Added .dotnet to PATH in $_rc"
-            _added=true
-            break
-          elif [[ -f "$_rc" ]] && grep -q '\.dotnet' "$_rc" 2>/dev/null; then
-            _added=true
-            break
-          fi
-        done
-        if [[ "$_added" == false ]]; then
-          echo "$_dotnet_line" >> "$HOME/.profile"
-          echo "  INFO: Added .dotnet to PATH in ~/.profile"
+      # Persist .dotnet/tools to PATH in shell rc
+      _dotnet_line='export PATH="$HOME/.dotnet:$HOME/.dotnet/tools:$PATH"'
+      _added=false
+      for _rc in "$HOME/.zshrc" "$HOME/.bashrc" "$HOME/.profile"; do
+        if [[ -f "$_rc" ]] && ! grep -q '\.dotnet' "$_rc" 2>/dev/null; then
+          echo "" >> "$_rc"
+          echo "# multiagent-setup: .NET tools path" >> "$_rc"
+          echo "$_dotnet_line" >> "$_rc"
+          echo "  INFO: Added .dotnet to PATH in $_rc"
+          _added=true
+          break
+        elif [[ -f "$_rc" ]] && grep -q '\.dotnet' "$_rc" 2>/dev/null; then
+          _added=true
+          break
         fi
+      done
+      if [[ "$_added" == false ]]; then
+        echo "$_dotnet_line" >> "$HOME/.profile"
+        echo "  INFO: Added .dotnet to PATH in ~/.profile"
       fi
     fi
-    echo "  OK: multiagent-setup $(multiagent-setup --version 2>/dev/null | awk '{print $2}')"
+    _ms_new="$(multiagent-setup --version 2>/dev/null | awk '{print $2}')"
+    if [[ "$_ms_new" != "$MULTIAGENT_VERSION" ]]; then
+      echo "  WARN: expected $MULTIAGENT_VERSION but got ${_ms_new:-unknown} — update may have failed"
+    else
+      echo "  OK: multiagent-setup $_ms_new"
+    fi
   fi
 elif [ "$OS" = "Darwin" ] && has brew; then
   echo "  ..  Installing multiagent-setup via Homebrew (no .NET required)..."
   brew install Neftedollar/multiagent-template/multiagent-setup
-  echo "  OK: multiagent-setup $(multiagent-setup --version 2>/dev/null | awk '{print $2}')"
+  _ms_new="$(multiagent-setup --version 2>/dev/null | awk '{print $2}')"
+  if [[ "$_ms_new" != "$MULTIAGENT_VERSION" ]]; then
+    echo "  WARN: expected $MULTIAGENT_VERSION but got ${_ms_new:-unknown} — install may have failed"
+  else
+    echo "  OK: multiagent-setup $_ms_new"
+  fi
 else
   echo "  ..  Installing multiagent-setup via dotnet tool..."
   dotnet tool install -g multiagent-setup
-  # Persist .dotnet/tools to PATH in shell rc (Linux only)
-  if [[ "$OS" != "Darwin" ]]; then
-    _dotnet_line='export PATH="$HOME/.dotnet:$HOME/.dotnet/tools:$PATH"'
-    _added=false
-    for _rc in "$HOME/.zshrc" "$HOME/.bashrc" "$HOME/.profile"; do
-      if [[ -f "$_rc" ]] && ! grep -q '\.dotnet' "$_rc" 2>/dev/null; then
-        echo "" >> "$_rc"
-        echo "# multiagent-setup: .NET tools path" >> "$_rc"
-        echo "$_dotnet_line" >> "$_rc"
-        echo "  INFO: Added .dotnet to PATH in $_rc"
-        _added=true
-        break
-      elif [[ -f "$_rc" ]] && grep -q '\.dotnet' "$_rc" 2>/dev/null; then
-        _added=true
-        break
-      fi
-    done
-    if [[ "$_added" == false ]]; then
-      echo "$_dotnet_line" >> "$HOME/.profile"
-      echo "  INFO: Added .dotnet to PATH in ~/.profile"
+  # Persist .dotnet/tools to PATH in shell rc
+  _dotnet_line='export PATH="$HOME/.dotnet:$HOME/.dotnet/tools:$PATH"'
+  _added=false
+  for _rc in "$HOME/.zshrc" "$HOME/.bashrc" "$HOME/.profile"; do
+    if [[ -f "$_rc" ]] && ! grep -q '\.dotnet' "$_rc" 2>/dev/null; then
+      echo "" >> "$_rc"
+      echo "# multiagent-setup: .NET tools path" >> "$_rc"
+      echo "$_dotnet_line" >> "$_rc"
+      echo "  INFO: Added .dotnet to PATH in $_rc"
+      _added=true
+      break
+    elif [[ -f "$_rc" ]] && grep -q '\.dotnet' "$_rc" 2>/dev/null; then
+      _added=true
+      break
     fi
+  done
+  if [[ "$_added" == false ]]; then
+    echo "$_dotnet_line" >> "$HOME/.profile"
+    echo "  INFO: Added .dotnet to PATH in ~/.profile"
   fi
-  echo "  OK: multiagent-setup $(multiagent-setup --version 2>/dev/null | awk '{print $2}')"
+  _ms_new="$(multiagent-setup --version 2>/dev/null | awk '{print $2}')"
+  if [[ "$_ms_new" != "$MULTIAGENT_VERSION" ]]; then
+    echo "  WARN: expected $MULTIAGENT_VERSION but got ${_ms_new:-unknown} — install may have failed"
+  else
+    echo "  OK: multiagent-setup $_ms_new"
+  fi
 fi
 
 # Detect init vs new mode:

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -15,6 +15,8 @@
 
 set -euo pipefail
 
+MULTIAGENT_VERSION="1.31.0"
+
 FIRST_ARG="${1:-}"
 if [[ -z "$FIRST_ARG" ]]; then
   echo "Usage: ./bootstrap.sh <project-name> [github-org] [--provider <name>]" >&2
@@ -73,7 +75,7 @@ echo "  OK: git"
 
 if [ "$OS" = "Darwin" ] && ! has brew; then
   echo "  ..  Installing Homebrew..."
-  /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+  /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)" # nosemgrep: curl-pipe-bash
   eval "$(/opt/homebrew/bin/brew shellenv 2>/dev/null || /usr/local/bin/brew shellenv 2>/dev/null)"
 fi
 
@@ -115,7 +117,7 @@ if ! has dotnet; then
   if [ "$OS" = "Darwin" ]; then
     brew install dotnet
   else
-    curl -fsSL https://dot.net/v1/dotnet-install.sh | bash -s -- --channel 10.0
+    curl -fsSL https://dot.net/v1/dotnet-install.sh | bash -s -- --channel 10.0 # nosemgrep: curl-pipe-bash
     export PATH="$HOME/.dotnet:$PATH"
   fi
 fi
@@ -127,10 +129,15 @@ if ! has claude; then
   echo "  ..  Installing Claude Code..."
   if has npm; then npm install -g @anthropic-ai/claude-code
   elif [ "$OS" = "Darwin" ] && has brew; then brew install claude
-  else echo "  WARN: install Claude Code manually: https://docs.anthropic.com/en/docs/claude-code"
   fi
 fi
-has claude && echo "  OK: claude" || true
+if has claude; then
+  echo "  OK: claude $(claude --version 2>/dev/null | head -1 || true)"
+else
+  echo "  WARN: Claude Code not installed — install manually:"
+  echo "        npm install -g @anthropic-ai/claude-code"
+  echo "        or: https://docs.anthropic.com/en/docs/claude-code"
+fi
 
 # ─── Create workspace ─────────────────────────────────────────
 
@@ -141,13 +148,71 @@ echo ""
 export PATH="$PATH:$HOME/.dotnet/tools"
 
 if has multiagent-setup; then
-  echo "  OK: multiagent-setup $(multiagent-setup --version 2>/dev/null || true)"
+  _ms_installed="$(multiagent-setup --version 2>/dev/null | awk '{print $2}')"
+  if [[ "$_ms_installed" == "$MULTIAGENT_VERSION" ]]; then
+    echo "  OK: multiagent-setup $_ms_installed"
+  else
+    echo "  ..  Updating multiagent-setup $_ms_installed → $MULTIAGENT_VERSION..."
+    if [ "$OS" = "Darwin" ] && has brew; then
+      brew upgrade Neftedollar/multiagent-template/multiagent-setup 2>/dev/null \
+        || brew reinstall Neftedollar/multiagent-template/multiagent-setup
+    else
+      dotnet tool update -g multiagent-setup
+      # Persist .dotnet/tools to PATH in shell rc (Linux only)
+      if [[ "$OS" != "Darwin" ]]; then
+        _dotnet_line='export PATH="$HOME/.dotnet:$HOME/.dotnet/tools:$PATH"'
+        _added=false
+        for _rc in "$HOME/.zshrc" "$HOME/.bashrc" "$HOME/.profile"; do
+          if [[ -f "$_rc" ]] && ! grep -q '\.dotnet' "$_rc" 2>/dev/null; then
+            echo "" >> "$_rc"
+            echo "# multiagent-setup: .NET tools path" >> "$_rc"
+            echo "$_dotnet_line" >> "$_rc"
+            echo "  INFO: Added .dotnet to PATH in $_rc"
+            _added=true
+            break
+          elif [[ -f "$_rc" ]] && grep -q '\.dotnet' "$_rc" 2>/dev/null; then
+            _added=true
+            break
+          fi
+        done
+        if [[ "$_added" == false ]]; then
+          echo "$_dotnet_line" >> "$HOME/.profile"
+          echo "  INFO: Added .dotnet to PATH in ~/.profile"
+        fi
+      fi
+    fi
+    echo "  OK: multiagent-setup $(multiagent-setup --version 2>/dev/null | awk '{print $2}')"
+  fi
 elif [ "$OS" = "Darwin" ] && has brew; then
   echo "  ..  Installing multiagent-setup via Homebrew (no .NET required)..."
   brew install Neftedollar/multiagent-template/multiagent-setup
+  echo "  OK: multiagent-setup $(multiagent-setup --version 2>/dev/null | awk '{print $2}')"
 else
   echo "  ..  Installing multiagent-setup via dotnet tool..."
   dotnet tool install -g multiagent-setup
+  # Persist .dotnet/tools to PATH in shell rc (Linux only)
+  if [[ "$OS" != "Darwin" ]]; then
+    _dotnet_line='export PATH="$HOME/.dotnet:$HOME/.dotnet/tools:$PATH"'
+    _added=false
+    for _rc in "$HOME/.zshrc" "$HOME/.bashrc" "$HOME/.profile"; do
+      if [[ -f "$_rc" ]] && ! grep -q '\.dotnet' "$_rc" 2>/dev/null; then
+        echo "" >> "$_rc"
+        echo "# multiagent-setup: .NET tools path" >> "$_rc"
+        echo "$_dotnet_line" >> "$_rc"
+        echo "  INFO: Added .dotnet to PATH in $_rc"
+        _added=true
+        break
+      elif [[ -f "$_rc" ]] && grep -q '\.dotnet' "$_rc" 2>/dev/null; then
+        _added=true
+        break
+      fi
+    done
+    if [[ "$_added" == false ]]; then
+      echo "$_dotnet_line" >> "$HOME/.profile"
+      echo "  INFO: Added .dotnet to PATH in ~/.profile"
+    fi
+  fi
+  echo "  OK: multiagent-setup $(multiagent-setup --version 2>/dev/null | awk '{print $2}')"
 fi
 
 # Detect init vs new mode:

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -15,7 +15,7 @@
 
 set -euo pipefail
 
-MULTIAGENT_VERSION="1.32.0"
+MULTIAGENT_VERSION="1.33.0"
 
 FIRST_ARG="${1:-}"
 if [[ -z "$FIRST_ARG" ]]; then
@@ -243,3 +243,45 @@ else
   [ -n "$PROVIDER" ]   && SETUP_ARGS+=("--provider" "$PROVIDER")
 fi
 multiagent-setup "${SETUP_ARGS[@]}"
+
+# Post-setup guidance
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "  Setup complete! What's next:"
+echo ""
+if [[ -n "${TARGET_DIR:-}" ]]; then
+  echo "  Workspace injected into: $TARGET_DIR"
+else
+  echo "  cd $PROJECT_NAME"
+fi
+echo ""
+_effective_provider="${PROVIDER:-claude}"
+case "$_effective_provider" in
+  claude|nessy)
+    echo "  Start the orchestrator:"
+    echo "    $_effective_provider"
+    echo "    /orchestrator Build the initial project skeleton"
+    ;;
+  gemini)
+    echo "  Start the orchestrator:"
+    echo "    gemini"
+    echo "    /orchestrator Build the initial project skeleton"
+    ;;
+  codex)
+    echo "  Start the orchestrator:"
+    echo "    codex"
+    echo "    /orchestrator Build the initial project skeleton"
+    ;;
+  qwen)
+    echo "  Start the orchestrator:"
+    echo "    qwen-code"
+    echo "    /orchestrator Build the initial project skeleton"
+    ;;
+  *)
+    echo "  Open the project in your IDE ($_effective_provider) and run:"
+    echo "    /orchestrator Build the initial project skeleton"
+    ;;
+esac
+echo ""
+echo "  Full docs: https://github.com/Neftedollar/multiagent-template"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -15,7 +15,7 @@
 
 set -euo pipefail
 
-MULTIAGENT_VERSION="1.31.0"
+MULTIAGENT_VERSION="1.32.0"
 
 FIRST_ARG="${1:-}"
 if [[ -z "$FIRST_ARG" ]]; then

--- a/docs/process.md
+++ b/docs/process.md
@@ -1,5 +1,8 @@
 # Operational Process
 
+> **MCPs are optional.** If you haven't run `install-mcps`, skip all graph/Cypher sections below.
+> Use GitHub Issues as your backlog. The pipeline works without AGE or O'Brien.
+
 > **Process v1**. Source of truth: AGE graph `{{GRAPH_NAME}}` + workflow specs.
 
 ## Source of truth
@@ -11,12 +14,14 @@
 | Security findings, Code insights | AGE graph `{{GRAPH_NAME}}` (SecurityFinding, CodeInsight nodes) |
 | Role capabilities (extended) | `docs/role-capabilities.md` |
 | Workflow specs | `docs/workflows/REGISTRY.md` → individual WORKFLOW-*.md |
-| Issues, dependencies | GitHub Project + graph (issue→DEPENDS_ON) |
-| Coordination | O'Brien (active-work, bugs, suggestions) |
+| Issues, dependencies | GitHub Project + graph (issue→DEPENDS_ON) <!-- requires AGE MCP --> |
+| Coordination | O'Brien (active-work, bugs, suggestions) <!-- requires AGE MCP --> |
 
 **Pipeline**: PLAN → BUILD → TEST → VERIFY → SHIP (5 steps, 5 pipelines: feature, bugfix, infra, content, spike).
 
 ## How agents use the graph
+
+<!-- requires AGE MCP -->
 
 Graph `{{GRAPH_NAME}}` is both process definition and **project knowledge base**. Each pipeline step is enriched with graph context:
 

--- a/docs/workflows/REGISTRY.md
+++ b/docs/workflows/REGISTRY.md
@@ -29,6 +29,7 @@
 | Software Architect | Feature (PLAN), Infra (PLAN) |
 | Senior Developer | Feature (BUILD, TEST), Bugfix (BUILD, TEST) |
 | Evidence Collector (`/testing-evidence-collector`) | Feature (TEST, conditional: UI) |
+| Reality Checker (`/testing-reality-checker`) | Feature (VERIFY), Bugfix (VERIFY) |
 | Performance Benchmarker (`/testing-performance-benchmarker`) | Feature (VERIFY, conditional) |
 | Code Reviewer | Feature (VERIFY), Bugfix (VERIFY) |
 | Security Engineer | Feature (VERIFY), Bugfix (VERIFY) |

--- a/docs/workflows/WORKFLOW-bugfix-pipeline.md
+++ b/docs/workflows/WORKFLOW-bugfix-pipeline.md
@@ -78,22 +78,25 @@ Triggered when fix touched UI files or issue has label `ui-bug`.
 ---
 
 ### STEP 3: VERIFY
-**Actor**: Code Reviewer + Security Engineer (parallel) + Performance Benchmarker (conditional)
+**Actor**: Code Reviewer + Security Engineer + Reality Checker (parallel) + Performance Benchmarker (conditional)
 **Gate**: `VERIFIED`
 **Timeout**: 15 min per reviewer
 
 All run **in parallel** (read code, don't write).
 
+**Reality Checker** — always runs. Validates: does the fix actually solve the reported bug? No regression in adjacent behaviour? Sanity-checks the fix against the issue description.
+
 **Performance Benchmarker** — triggered when bug was performance-related or fix touches hot paths.
 
-**Output on SUCCESS**: `{ code_review: "APPROVED", security_review: "APPROVED", perf_review?: "APPROVED", status: "VERIFIED" }` → GO TO STEP 4
+**Output on SUCCESS**: `{ code_review: "APPROVED", security_review: "APPROVED", reality_check: "APPROVED", perf_review?: "APPROVED", status: "VERIFIED" }` → GO TO STEP 4
 
 **Output on FAILURE**:
 - `NEEDS_WORK(code_quality)` → return to STEP 1
 - `NEEDS_WORK(security_issue)` → return to STEP 1, PRIORITY: security fix
 - `NEEDS_WORK(perf_issue)` → return to STEP 1
+- `NEEDS_WORK(reality_fail, details)` → return to STEP 1
 
-**Merge rule**: Code Reviewer + Security Engineer MUST return APPROVED.
+**Merge rule**: Code Reviewer + Security Engineer + Reality Checker MUST return APPROVED.
 
 ---
 

--- a/docs/workflows/WORKFLOW-feature-pipeline.md
+++ b/docs/workflows/WORKFLOW-feature-pipeline.md
@@ -121,7 +121,7 @@ Triggered when BUILD touched UI files (`*.html`, `*.css`, `*.tsx`, `*.jsx`, `*.v
 ---
 
 ### STEP 4: VERIFY
-**Actor**: Code Reviewer + Security Engineer + Performance Benchmarker (all parallel)
+**Actor**: Code Reviewer + Security Engineer + Reality Checker + Performance Benchmarker (all parallel)
 **Gate**: `VERIFIED`
 **Timeout**: 15 min per reviewer
 
@@ -130,6 +130,8 @@ All run **in parallel** (read code, don't write).
 **Action (Code Reviewer)**: quality patterns, maintainability, test coverage.
 
 **Action (Security Engineer)**: OWASP, auth, injection, data exposure.
+
+**Action (Reality Checker)**: end-to-end sanity check — does the implementation actually solve the issue? Does the change match the acceptance criteria? Are there unintended side effects? Validates the "big picture" before merge.
 
 **Action (Performance Benchmarker — conditional)**:
 
@@ -141,14 +143,15 @@ Triggered when BUILD changed backend code (routes, queries, services) or fronten
 4. Identify O(n^2)+ algorithms on potentially large datasets
 5. Flag missing pagination, unbounded queries, missing caching
 
-**Output on SUCCESS**: `{ code_review: "APPROVED", security_review: "APPROVED", perf_review?: "APPROVED", status: "VERIFIED" }` → GO TO STEP 5
+**Output on SUCCESS**: `{ code_review: "APPROVED", security_review: "APPROVED", reality_check: "APPROVED", perf_review?: "APPROVED", status: "VERIFIED" }` → GO TO STEP 5
 
 **Output on FAILURE**:
 - `NEEDS_WORK(code_quality)` → return to STEP 2
 - `NEEDS_WORK(security_issue)` → return to STEP 2, PRIORITY: security fix
 - `NEEDS_WORK(perf_issue, details)` → return to STEP 2
+- `NEEDS_WORK(reality_fail, details)` → return to STEP 2
 
-**Merge rule**: Code Reviewer + Security Engineer MUST return APPROVED. Performance Benchmarker issues are advisory unless critical (unbounded queries, memory leaks).
+**Merge rule**: Code Reviewer + Security Engineer + Reality Checker MUST return APPROVED. Performance Benchmarker issues are advisory unless critical (unbounded queries, memory leaks).
 
 ---
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -120,7 +120,7 @@ Re-extracts the latest `docs/`, `tools/`, hook configs, and provider-specific fi
 ### `install-mcps` — Install optional memory infrastructure
 
 ```bash
-multiagent-setup install-mcps [--docker|--manual] [--age-conn <str>] [--obrien-conn <str>]
+multiagent-setup install-mcps [--docker|--manual] [--age-conn <str>] [--obrien-conn <str>] [--target <dir>]
 ```
 
 Installs optional MCP servers:
@@ -144,10 +144,12 @@ Runs a compiled safety hook. All hooks are baked into the binary (no shell scrip
 ### `doctor` — Workspace health check
 
 ```bash
-multiagent-setup doctor
+multiagent-setup doctor [--for <command>]
 ```
 
 Checks the current workspace for common configuration issues: missing required files, undetected providers, hook configuration problems, and missing binaries. Run after `update` or when something seems wrong.
+
+`--for <command>` — pre-flight mode: runs targeted checks for a specific command before executing it. Supported values: `sync-roles`, `init`, `update`.
 
 ## Supported Providers
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -70,6 +70,7 @@ Syncs the latest agent role files from [agency-agents](https://github.com/msitar
 Auto-detected additional targets:
 - `./.qwen/commands/` — if Qwen workspace is present
 - `./.codex/skills/` — if Codex workspace is present
+- `~/.gemini/extensions/agency-agents/` — if `.gemini/` workspace or `--global` is set (TOML format)
 
 ### `add-provider` — Add provider to existing workspace
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -52,7 +52,7 @@ dotnet tool install -g multiagent-setup
 ### `new` — Create workspace
 
 ```bash
-multiagent-setup new <project-name> [github-org] [--provider <name>]
+multiagent-setup new <project-name> [github-org] [--provider <name>] [--template <name>]
 ```
 
 Creates a workspace directory at `./project-name/`. Clones agency-agents and syncs roles globally to `~/.claude/commands/`. Initializes a git repo in the workspace.
@@ -60,6 +60,14 @@ Creates a workspace directory at `./project-name/`. Clones agency-agents and syn
 Providers: `claude` (default), `gemini`, `codex`, `qwen`, `cursor`, `windsurf`, `copilot`, `nessy`, `cline`, `aider`, `continue`, `roo`, `all`
 
 Templates: `default` (generic), `saas` (SaaS product — user impact, feature flags, analytics, SLO gates), `oss` (Open Source — CHANGELOG, semver, backward-compat gates, contributor guidelines), `internal` (Internal tools — simplified pipeline, lighter gates, speed over ceremony)
+
+### `init` — Add workspace to existing repo
+
+```bash
+multiagent-setup init [dir] [--provider <name>] [--template <name>] [--force]
+```
+
+Adds workspace files (CLAUDE.md, docs/, .claude/, hooks) to an existing git repository without creating a new directory or touching your code. `dir` defaults to the current directory. Must already be a git repository. `--force` overwrites existing files.
 
 ### `sync-roles` — Update agent roles
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -55,13 +55,14 @@ Providers: `claude` (default), `gemini`, `codex`, `qwen`, `cursor`, `windsurf`, 
 ### `sync-roles` — Update agent roles
 
 ```bash
-multiagent-setup sync-roles [--clone|--pull] [--agency-dir <path>]
+multiagent-setup sync-roles [--clone|--pull] [--global] [--agency-dir <path>]
 ```
 
-Syncs the latest agent role files from [agency-agents](https://github.com/msitarzewski/agency-agents) to:
-- `~/.claude/commands/` — Claude, Nessy, Gemini, Cursor, Windsurf, Copilot
-- `./.qwen/commands/` — auto-detected if Qwen workspace is present
-- `./.codex/skills/` — auto-detected if Codex workspace is present
+Syncs the latest agent role files from [agency-agents](https://github.com/msitarzewski/agency-agents) to the local workspace `.claude/commands/` by default. Add `--global` to also sync to `~/.claude/commands/`.
+
+Auto-detected additional targets:
+- `./.qwen/commands/` — if Qwen workspace is present
+- `./.codex/skills/` — if Codex workspace is present
 
 ### `add-provider` — Add provider to existing workspace
 
@@ -71,6 +72,24 @@ multiagent-setup add-provider all [--force]
 ```
 
 Adds a new provider's scaffold (config files, hooks, role commands) to an existing workspace without rebuilding from scratch. Use `all` to add every provider at once (nessy, codex, qwen, cursor, windsurf, copilot, gemini, cline, aider, continue, roo).
+
+### `remove-provider` — Remove a provider from workspace
+
+```bash
+multiagent-setup remove-provider <provider> [--force]
+```
+
+Removes a provider's directories and workspace instructions file. Skips shared infrastructure (`.claude/`, `.github/`) and directories used by other active providers. Prompts for confirmation unless `--force` is set.
+
+Cannot remove `claude` (base provider).
+
+### `list-providers` — Show installed and available providers
+
+```bash
+multiagent-setup list-providers
+```
+
+Lists all providers with their installation status (`[installed]` or `[available]`) and workspace instructions file. Must be run from a workspace root.
 
 ### `update` — Update workspace templates to latest version
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -13,7 +13,14 @@ This file is the comprehensive reference. See also: [llms.txt](llms.txt) for the
 
 ## What It Does
 
-`multiagent-setup` is a .NET 10 dotnet global tool that scaffolds a **multi-agent workspace** directory for your software project. The workspace contains:
+`multiagent-setup` is a .NET 10 dotnet global tool that solves the core problem of single-agent AI code generation: **context collapse, no accountability, inconsistent code quality**. It scaffolds a structured multi-agent workspace with:
+
+- **Role separation** — Orchestrator never writes code; architects design, developers build, reviewers validate independently
+- **Gated pipeline** — PLAN → BUILD → TEST → VERIFY → SHIP, with approval gates and automatic retry (3× same role, 2× helper role, then escalate to human)
+- **Provider agnostic** — Works with 12 AI coding agents: Claude, Gemini, Codex, Cursor, Windsurf, Cline, Aider, Continue, Roo, Qwen, Copilot, Nessy
+- **Safety-by-default** — Blocks destructive commands, enforces conventional commits, auto-lints on save
+
+The workspace contains:
 
 1. A context file (CLAUDE.md / AGENTS.md / GEMINI.md / etc.) that tells the AI its role and the pipeline rules
 2. A set of slash-command role files (`/orchestrator`, `/engineering-backend-architect`, etc.)

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -59,6 +59,8 @@ Creates a workspace directory at `./project-name/`. Clones agency-agents and syn
 
 Providers: `claude` (default), `gemini`, `codex`, `qwen`, `cursor`, `windsurf`, `copilot`, `nessy`, `cline`, `aider`, `continue`, `roo`, `all`
 
+Templates: `default` (generic), `saas` (SaaS product — user impact, feature flags, analytics, SLO gates), `oss` (Open Source — CHANGELOG, semver, backward-compat gates, contributor guidelines), `internal` (Internal tools — simplified pipeline, lighter gates, speed over ceremony)
+
 ### `sync-roles` — Update agent roles
 
 ```bash

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -57,7 +57,7 @@ multiagent-setup new <project-name> [github-org] [--provider <name>] [--template
 
 Creates a workspace directory at `./project-name/`. Clones agency-agents and syncs roles globally to `~/.claude/commands/`. Initializes a git repo in the workspace.
 
-Providers: `claude` (default), `gemini`, `codex`, `qwen`, `cursor`, `windsurf`, `copilot`, `nessy`, `cline`, `aider`, `continue`, `roo`, `all`
+Providers: `claude` (default), `gemini`, `codex`, `qwen`, `cursor`, `windsurf`, `copilot`, `nessy`, `cline`, `aider`, `continue`, `roo`, `kiro`, `all`
 
 Templates: `default` (generic), `saas` (SaaS product — user impact, feature flags, analytics, SLO gates), `oss` (Open Source — CHANGELOG, semver, backward-compat gates, contributor guidelines), `internal` (Internal tools — simplified pipeline, lighter gates, speed over ceremony)
 
@@ -89,7 +89,7 @@ multiagent-setup add-provider <provider> [--force]
 multiagent-setup add-provider all [--force]
 ```
 
-Adds a new provider's scaffold (config files, hooks, role commands) to an existing workspace without rebuilding from scratch. Use `all` to add every provider at once (nessy, codex, qwen, cursor, windsurf, copilot, gemini, cline, aider, continue, roo).
+Adds a new provider's scaffold (config files, hooks, role commands) to an existing workspace without rebuilding from scratch. Use `all` to add every provider at once (nessy, codex, qwen, cursor, windsurf, copilot, gemini, cline, aider, continue, roo, kiro).
 
 ### `remove-provider` — Remove a provider from workspace
 
@@ -174,6 +174,7 @@ Checks the current workspace for common configuration issues: missing required f
 | `aider` | Aider (terminal) | `.aider.conf.yml` | `CLAUDE.md` (auto-read) |
 | `continue` | VS Code/JetBrains Continue | `.continue/config.yaml` | `.continue/config.yaml` |
 | `roo` | VS Code Roo Code extension | `.roo/rules/workspace.md` | `.roo/rules/workspace.md` |
+| `kiro` | VS Code Amazon Kiro extension | `.kiro/steering/workspace.md` (inclusion: always) | `.kiro/steering/workspace.md` |
 
 ## Pipeline System
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -94,10 +94,10 @@ Adds a new provider's scaffold (config files, hooks, role commands) to an existi
 ### `remove-provider` — Remove a provider from workspace
 
 ```bash
-multiagent-setup remove-provider <provider> [--force]
+multiagent-setup remove-provider <provider> [--force] [--dry-run]
 ```
 
-Removes a provider's directories and workspace instructions file. Skips shared infrastructure (`.claude/`, `.github/`) and directories used by other active providers. Prompts for confirmation unless `--force` is set.
+Removes a provider's directories and workspace instructions file. Skips shared infrastructure (`.claude/`, `.github/`) and directories used by other active providers. Prompts for confirmation unless `--force` is set. Use `--dry-run` to preview what would be deleted without making any changes.
 
 Cannot remove `claude` (base provider).
 
@@ -112,10 +112,10 @@ Lists all providers with their installation status (`[installed]` or `[available
 ### `update` — Update workspace templates to latest version
 
 ```bash
-multiagent-setup update [--force]
+multiagent-setup update [--force] [--dry-run]
 ```
 
-Re-extracts the latest `docs/`, `tools/`, hook configs, and provider-specific files into an existing workspace. Auto-detects which providers are installed. Skips user-customised context files (`CLAUDE.md`, `GEMINI.md`, `QWEN.md`, `AGENTS.md`) by default. Use `--force` to overwrite all files.
+Re-extracts the latest `docs/`, `tools/`, hook configs, and provider-specific files into an existing workspace. Auto-detects which providers are installed. Skips user-customised context files (`CLAUDE.md`, `GEMINI.md`, `QWEN.md`, `AGENTS.md`) by default. Use `--force` to overwrite all files. Use `--dry-run` to preview what would be created or overwritten without writing anything.
 
 ### `install-mcps` — Install optional memory infrastructure
 
@@ -150,6 +150,23 @@ multiagent-setup doctor [--for <command>]
 Checks the current workspace for common configuration issues: missing required files, undetected providers, hook configuration problems, and missing binaries. Run after `update` or when something seems wrong.
 
 `--for <command>` — pre-flight mode: runs targeted checks for a specific command before executing it. Supported values: `sync-roles`, `init`, `update`.
+
+### `completions` — Print shell completion script
+
+```bash
+multiagent-setup completions zsh    # zsh completion script
+multiagent-setup completions pwsh   # PowerShell completion script
+```
+
+Prints the shell completion script to stdout. Install with:
+
+```bash
+eval "$(multiagent-setup completions zsh)"          # source inline
+multiagent-setup completions zsh >> ~/.zshrc         # persist to zshrc
+multiagent-setup completions pwsh >> $PROFILE        # persist to PowerShell profile
+```
+
+Completions cover all subcommands, providers, templates, hooks, and flags.
 
 ## Supported Providers
 

--- a/llms.txt
+++ b/llms.txt
@@ -78,13 +78,14 @@ All safety hooks are baked into the `multiagent-setup` binary (cross-platform, n
 multiagent-setup new <project> [org] [--provider <name>] [--template default|saas|oss|internal]
 multiagent-setup init [dir] [--provider <name>] [--template <name>] [--force]
 multiagent-setup add-provider <provider>|all [--force]
-multiagent-setup remove-provider <provider> [--force]
+multiagent-setup remove-provider <provider> [--force] [--dry-run]
 multiagent-setup list-providers
-multiagent-setup update [--force]
+multiagent-setup update [--force] [--dry-run]
 multiagent-setup sync-roles [--clone|--pull] [--global] [--agency-dir <path>]
 multiagent-setup install-mcps [--docker|--manual] [--age-conn <str>] [--obrien-conn <str>] [--target <dir>]
 multiagent-setup hook <name>
 multiagent-setup doctor [--for sync-roles|init|update]
+multiagent-setup completions zsh|pwsh
 ```
 
 ## Source Structure

--- a/llms.txt
+++ b/llms.txt
@@ -74,16 +74,16 @@ All safety hooks are baked into the `multiagent-setup` binary (cross-platform, n
 ## CLI Reference
 
 ```
-multiagent-setup new <project> [org] [--provider <name>]
-multiagent-setup init [dir] [--provider <name>] [--force]
+multiagent-setup new <project> [org] [--provider <name>] [--template default|saas|oss|internal]
+multiagent-setup init [dir] [--provider <name>] [--template <name>] [--force]
 multiagent-setup add-provider <provider>|all [--force]
 multiagent-setup remove-provider <provider> [--force]
 multiagent-setup list-providers
 multiagent-setup update [--force]
 multiagent-setup sync-roles [--clone|--pull] [--global] [--agency-dir <path>]
-multiagent-setup install-mcps [--docker|--manual]
+multiagent-setup install-mcps [--docker|--manual] [--age-conn <str>] [--obrien-conn <str>] [--target <dir>]
 multiagent-setup hook <name>
-multiagent-setup doctor
+multiagent-setup doctor [--for sync-roles|init|update]
 ```
 
 ## Source Structure

--- a/llms.txt
+++ b/llms.txt
@@ -1,6 +1,6 @@
 # multiagent-template
 
-> Orchestrate teams of AI coding agents in a structured pipeline (PLAN → BUILD → TEST → VERIFY → SHIP). Unlike single-agent tools, multiagent-template prevents context collapse and ensures accountability via role separation and approval gates. Works with 12 providers: Claude, Gemini, Codex, Cursor, Windsurf, Cline, Aider, Continue, Roo, Qwen, Copilot, Nessy.
+> Orchestrate teams of AI coding agents in a structured pipeline (PLAN → BUILD → TEST → VERIFY → SHIP). Unlike single-agent tools, multiagent-template prevents context collapse and ensures accountability via role separation and approval gates. Works with 13 providers: Claude, Gemini, Codex, Cursor, Windsurf, Cline, Aider, Continue, Roo, Qwen, Copilot, Nessy, Kiro.
 
 ## The Problem
 
@@ -48,6 +48,7 @@ multiagent-setup new MyProject
 - **Aider** (`aider`) — Aider AI pair programmer; config via `.aider.conf.yml` (auto-reads CLAUDE.md)
 - **Continue.dev** (`continue`) — VS Code/JetBrains extension; config via `.continue/config.yaml` with `/orchestrator` slash command
 - **Roo Code** (`roo`) — Roo Code VS Code extension; rules auto-loaded from `.roo/rules/`
+- **Amazon Kiro** (`kiro`) — Kiro VS Code extension (AWS); steering docs auto-loaded from `.kiro/steering/`
 
 Use `--provider all` to scaffold all providers at once, `add-provider <name>` (or `add-provider all`) to add providers to an existing workspace, `remove-provider <name>` to remove one, `list-providers` to see installed vs. available, or `update` to pull the latest templates into an existing workspace.
 
@@ -90,7 +91,7 @@ multiagent-setup doctor [--for sync-roles|init|update]
 
 - `tools/setup-cli/` — .NET CLI source (C#, .NET 10)
 - `tools/setup-cli/Templates/` — embedded workspace templates
-- `tools/setup-cli/Templates/providers/` — provider-specific configs (codex, qwen, cursor, windsurf, copilot, gemini, cline, aider, continue, roo)
+- `tools/setup-cli/Templates/providers/` — provider-specific configs (codex, qwen, cursor, windsurf, copilot, gemini, cline, aider, continue, roo, kiro)
 - `tools/setup-cli/Templates/.claude/` — Claude/Nessy config templates
 - `tools/setup-cli/Templates/docs/` — process.md, role-capabilities.md, workflow specs
 

--- a/llms.txt
+++ b/llms.txt
@@ -49,7 +49,7 @@ multiagent-setup new MyProject
 - **Continue.dev** (`continue`) — VS Code/JetBrains extension; config via `.continue/config.yaml` with `/orchestrator` slash command
 - **Roo Code** (`roo`) — Roo Code VS Code extension; rules auto-loaded from `.roo/rules/`
 
-Use `--provider all` to scaffold all providers at once, `add-provider <name>` (or `add-provider all`) to add providers to an existing workspace, or `update` to pull the latest templates into an existing workspace.
+Use `--provider all` to scaffold all providers at once, `add-provider <name>` (or `add-provider all`) to add providers to an existing workspace, `remove-provider <name>` to remove one, `list-providers` to see installed vs. available, or `update` to pull the latest templates into an existing workspace.
 
 ## Key Concepts
 
@@ -75,9 +75,12 @@ All safety hooks are baked into the `multiagent-setup` binary (cross-platform, n
 
 ```
 multiagent-setup new <project> [org] [--provider <name>]
+multiagent-setup init [dir] [--provider <name>] [--force]
 multiagent-setup add-provider <provider>|all [--force]
+multiagent-setup remove-provider <provider> [--force]
+multiagent-setup list-providers
 multiagent-setup update [--force]
-multiagent-setup sync-roles [--clone|--pull] [--agency-dir <path>]
+multiagent-setup sync-roles [--clone|--pull] [--global] [--agency-dir <path>]
 multiagent-setup install-mcps [--docker|--manual]
 multiagent-setup hook <name>
 multiagent-setup doctor

--- a/llms.txt
+++ b/llms.txt
@@ -1,6 +1,6 @@
 # multiagent-template
 
-> A scaffold for autonomous multi-agent AI development workspaces. One command creates a full team of specialized AI agents (orchestrator, architect, developer, reviewer, DevOps, designer) that autonomously drives software from backlog to merged PR across 12 AI coding agent providers.
+> Orchestrate teams of AI coding agents in a structured pipeline (PLAN → BUILD → TEST → VERIFY → SHIP). Unlike single-agent tools, multiagent-template prevents context collapse and ensures accountability via role separation and approval gates. Works with 12 providers: Claude, Gemini, Codex, Cursor, Windsurf, Cline, Aider, Continue, Roo, Qwen, Copilot, Nessy.
 
 ## The Problem
 

--- a/tools/setup-cli.Tests/MultiagentSetup.Tests/ProviderRegistryTests.cs
+++ b/tools/setup-cli.Tests/MultiagentSetup.Tests/ProviderRegistryTests.cs
@@ -9,9 +9,9 @@ public class ProviderRegistryTests
     // ── Provider count ────────────────────────────────────────────────────────
 
     [Fact]
-    public void All_Has12Providers()
+    public void All_Has13Providers()
     {
-        Assert.Equal(12, ProviderRegistry.All.Count);
+        Assert.Equal(13, ProviderRegistry.All.Count);
     }
 
     [Fact]
@@ -21,9 +21,9 @@ public class ProviderRegistryTests
     }
 
     [Fact]
-    public void ValidForNew_Has13Entries_12ProvidersPlusAll()
+    public void ValidForNew_Has14Entries_13ProvidersPlusAll()
     {
-        Assert.Equal(13, ProviderRegistry.ValidForNew.Count);
+        Assert.Equal(14, ProviderRegistry.ValidForNew.Count);
     }
 
     [Fact]
@@ -41,10 +41,10 @@ public class ProviderRegistryTests
     }
 
     [Fact]
-    public void AllExpansion_Includes11Providers()
+    public void AllExpansion_Includes12Providers()
     {
-        // All 12 minus nessy (which shares .claude/ with claude)
-        Assert.Equal(11, ProviderRegistry.AllExpansion.Count);
+        // All 13 minus nessy (which shares .claude/ with claude)
+        Assert.Equal(12, ProviderRegistry.AllExpansion.Count);
     }
 
     // ── Find ──────────────────────────────────────────────────────────────────
@@ -62,6 +62,7 @@ public class ProviderRegistryTests
     [InlineData("aider")]
     [InlineData("continue")]
     [InlineData("roo")]
+    [InlineData("kiro")]
     public void Find_ReturnsProvider_ForEachValidName(string name)
     {
         var def = ProviderRegistry.Find(name);

--- a/tools/setup-cli/CompletionsCommand.cs
+++ b/tools/setup-cli/CompletionsCommand.cs
@@ -1,0 +1,44 @@
+using System.Reflection;
+using System.Text;
+
+namespace MultiagentSetup;
+
+public sealed class CompletionsCommand(string shell)
+{
+    private static readonly Dictionary<string, string> ShellToResource = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["zsh"]  = "tools/completions.zsh",
+        ["pwsh"] = "tools/completions.ps1",
+        ["ps1"]  = "tools/completions.ps1",
+    };
+
+    public async Task<int> ExecuteAsync()
+    {
+        if (!ShellToResource.TryGetValue(shell, out var resourceName))
+        {
+            Console.Error.WriteLine($"Unsupported shell '{shell}'. Supported: zsh, pwsh");
+            Console.Error.WriteLine();
+            Console.Error.WriteLine("Usage:");
+            Console.Error.WriteLine("  multiagent-setup completions zsh   # zsh");
+            Console.Error.WriteLine("  multiagent-setup completions pwsh  # PowerShell");
+            Console.Error.WriteLine();
+            Console.Error.WriteLine("Install examples:");
+            Console.Error.WriteLine("  eval \"$(multiagent-setup completions zsh)\"");
+            Console.Error.WriteLine("  multiagent-setup completions zsh >> ~/.zshrc");
+            return 1;
+        }
+
+        var asm = Assembly.GetExecutingAssembly();
+        using var stream = asm.GetManifestResourceStream(resourceName);
+        if (stream is null)
+        {
+            Console.Error.WriteLine($"Internal error: completions resource '{resourceName}' not found.");
+            return 1;
+        }
+
+        using var reader = new StreamReader(stream, Encoding.UTF8);
+        var content = await reader.ReadToEndAsync();
+        Console.Write(content);
+        return 0;
+    }
+}

--- a/tools/setup-cli/DoctorCommand.cs
+++ b/tools/setup-cli/DoctorCommand.cs
@@ -1,11 +1,15 @@
 namespace MultiagentSetup;
 
-public sealed class DoctorCommand(string? workspaceRoot = null, string? homeDir = null)
+public sealed class DoctorCommand(string? workspaceRoot = null, string? homeDir = null, string? forCommand = null)
 {
     public async Task<int> ExecuteAsync()
     {
         var cwd  = workspaceRoot ?? Directory.GetCurrentDirectory();
         var home = homeDir       ?? Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+
+        // Pre-flight mode: targeted checks for a specific command
+        if (forCommand is not null)
+            return await RunPreflightAsync(cwd, forCommand);
 
         Console.WriteLine("multiagent-setup doctor");
         Console.WriteLine("=======================");
@@ -111,6 +115,88 @@ public sealed class DoctorCommand(string? workspaceRoot = null, string? homeDir 
             if (warnings > 0)
                 Console.WriteLine($"{warnings} warning(s) — workspace may have reduced functionality.");
         }
+        Console.WriteLine();
+        return errors > 0 ? 1 : 0;
+    }
+
+    // ── Pre-flight mode ────────────────────────────────────────────────────────
+
+    private static async Task<int> RunPreflightAsync(string cwd, string command)
+    {
+        Console.WriteLine($"Pre-flight check: multiagent-setup {command}");
+        Console.WriteLine();
+        int errors = 0;
+
+        switch (command.ToLowerInvariant())
+        {
+            case "sync-roles":
+            {
+                errors += Check(ProcessHelper.IsOnPath("git"), "git is on PATH");
+
+                var agencyDir = Environment.GetEnvironmentVariable("AGENCY_DIR")
+                    ?? Path.GetFullPath(Path.Combine(cwd, "..", "agency-agents"));
+
+                if (Directory.Exists(Path.Combine(agencyDir, ".git")))
+                {
+                    Console.WriteLine($"  OK   agency-agents found at {agencyDir}");
+                }
+                else
+                {
+                    Console.WriteLine($"  WARN agency-agents not found at {agencyDir}");
+                    Console.WriteLine( "       Run: multiagent-setup sync-roles --clone");
+                    errors++;
+                }
+
+                var hasLocalClaude = Directory.Exists(Path.Combine(cwd, ".claude"));
+                if (hasLocalClaude)
+                    Console.WriteLine($"  OK   local .claude/ workspace found");
+                else
+                {
+                    Console.WriteLine($"  WARN no local .claude/ workspace — roles will only sync with --global");
+                    Console.WriteLine( "       Run: multiagent-setup sync-roles --clone --global");
+                }
+                break;
+            }
+
+            case "init":
+            {
+                errors += Check(ProcessHelper.IsOnPath("git"), "git is on PATH");
+                errors += Check(ProcessHelper.IsOnPath("gh"),  "gh (GitHub CLI) is on PATH");
+
+                var (code, _, _) = await ProcessHelper.RunAsync("git",
+                    ["rev-parse", "--git-dir"], workingDir: cwd,
+                    captureOutput: true, allowFailure: true);
+                if (code == 0)
+                    Console.WriteLine($"  OK   {cwd} is a git repository");
+                else
+                {
+                    Console.WriteLine($"  FAIL {cwd} is NOT a git repository");
+                    Console.WriteLine( "       Run: git init, then re-run multiagent-setup init");
+                    errors++;
+                }
+                break;
+            }
+
+            case "update":
+            {
+                var hasClaude  = File.Exists(Path.Combine(cwd, "CLAUDE.md"));
+                var hasProcess = File.Exists(Path.Combine(cwd, "docs", "process.md"));
+                errors += Check(hasClaude,  "CLAUDE.md found (workspace root)");
+                errors += Check(hasProcess, "docs/process.md found");
+                break;
+            }
+
+            default:
+                Console.Error.WriteLine($"Unknown command for --for: {command}");
+                Console.Error.WriteLine("Supported: sync-roles, init, update");
+                return 1;
+        }
+
+        Console.WriteLine();
+        if (errors == 0)
+            Console.WriteLine($"Pre-flight passed — {command} should succeed.");
+        else
+            Console.WriteLine($"{errors} issue(s) found — fix above before running {command}.");
         Console.WriteLine();
         return errors > 0 ? 1 : 0;
     }

--- a/tools/setup-cli/DoctorCommand.cs
+++ b/tools/setup-cli/DoctorCommand.cs
@@ -75,7 +75,8 @@ public sealed class DoctorCommand(string? workspaceRoot = null, string? homeDir 
             || File.Exists(Path.Combine(cwd, ".clinerules"))
             || File.Exists(Path.Combine(cwd, ".aider.conf.yml"))
             || Directory.Exists(Path.Combine(cwd, ".continue"))
-            || Directory.Exists(Path.Combine(cwd, ".roo", "rules"));
+            || Directory.Exists(Path.Combine(cwd, ".roo", "rules"))
+            || Directory.Exists(Path.Combine(cwd, ".kiro"));
 
         if (foundAgents.Length == 0 && !hasIdeProviders)
         {
@@ -85,7 +86,7 @@ public sealed class DoctorCommand(string? workspaceRoot = null, string? homeDir 
         foreach (var a in foundAgents)
             Console.WriteLine($"  OK   {a}");
         if (hasIdeProviders)
-            Console.WriteLine("  OK   IDE/extension provider (cursor/windsurf/copilot/cline/aider/continue/roo) detected");
+            Console.WriteLine("  OK   IDE/extension provider (cursor/windsurf/copilot/cline/aider/continue/roo/kiro) detected");
         Console.WriteLine();
 
         // ── Optional infrastructure ───────────────────────────────────────────

--- a/tools/setup-cli/HooksCommand.cs
+++ b/tools/setup-cli/HooksCommand.cs
@@ -276,7 +276,11 @@ public sealed class HooksCommand(string hookName)
         var (code, diff, _) = await ProcessHelper.RunAsync("git",
             ["-C", projDir, "diff", "--name-only", baseline],
             captureOutput: true, allowFailure: true);
-        if (code != 0) return false;
+        if (code != 0)
+        {
+            Console.Error.WriteLine($"  WARN: stop-guard git diff failed (baseline: {baseline[..Math.Min(8, baseline.Length)]}...) — skipping check");
+            return false;
+        }
         return Regex.IsMatch(diff,
             @"\.(ts|tsx|js|jsx|py|go|rs|rb|php|fs|fsx|cs|java|kt|swift|vue|svelte)$",
             RegexOptions.Multiline);

--- a/tools/setup-cli/HooksCommand.cs
+++ b/tools/setup-cli/HooksCommand.cs
@@ -91,10 +91,13 @@ public sealed class HooksCommand(string hookName)
         var command = JsonGet(input, "tool_input", "command");
         if (string.IsNullOrEmpty(command)) return 0;
 
-        // Only intercept actual git-commit invocations — not commands that
-        // mention "git commit" in their arguments (e.g. gh issue create --body "...git commit...").
-        // Match: optional leading whitespace/pipe, then "git" as first executable token, then "commit".
-        if (!Regex.IsMatch(command, @"(?:^|[|&;]\s*)git\s+commit\b", RegexOptions.IgnoreCase)) return 0;
+        // Only intercept actual git-commit invocations — not commands that mention
+        // "git commit" in their arguments (e.g. gh pr create --body "...git commit...").
+        // Check only the first executable token to avoid false positives.
+        var tokens = command.TrimStart().Split(new[] { ' ', '\t', '\n', '\r' }, 3, StringSplitOptions.RemoveEmptyEntries);
+        if (tokens.Length < 2) return 0;
+        if (!tokens[0].Equals("git", StringComparison.OrdinalIgnoreCase)) return 0;
+        if (!tokens[1].Equals("commit", StringComparison.OrdinalIgnoreCase)) return 0;
 
         var msg = ExtractCommitMessage(command);
         if (string.IsNullOrEmpty(msg)) return 0;
@@ -247,8 +250,31 @@ public sealed class HooksCommand(string hookName)
 
     private static async Task<bool> HasCodeChangesAsync(string projDir)
     {
+        // Use a session-scoped baseline so pre-session changes don't trigger stop-guard.
+        // On first invocation, capture the current HEAD and store it in a temp file.
+        // Subsequent invocations compare against that baseline instead of current HEAD.
+        var sessionId = Environment.GetEnvironmentVariable("CLAUDE_SESSION_ID")
+                        ?? Environment.GetEnvironmentVariable("TERM_SESSION_ID")
+                        ?? "default";
+        var baselineFile = Path.Combine(Path.GetTempPath(), $"multiagent-stop-baseline-{sessionId}");
+
+        string baseline;
+        if (File.Exists(baselineFile))
+        {
+            baseline = (await File.ReadAllTextAsync(baselineFile)).Trim();
+        }
+        else
+        {
+            var (revCode, revOut, _) = await ProcessHelper.RunAsync("git",
+                ["-C", projDir, "rev-parse", "HEAD"],
+                captureOutput: true, allowFailure: true);
+            if (revCode != 0) return false;
+            baseline = revOut.Trim();
+            await File.WriteAllTextAsync(baselineFile, baseline);
+        }
+
         var (code, diff, _) = await ProcessHelper.RunAsync("git",
-            ["-C", projDir, "diff", "--name-only", "HEAD"],
+            ["-C", projDir, "diff", "--name-only", baseline],
             captureOutput: true, allowFailure: true);
         if (code != 0) return false;
         return Regex.IsMatch(diff,

--- a/tools/setup-cli/HooksCommand.cs
+++ b/tools/setup-cli/HooksCommand.cs
@@ -289,6 +289,7 @@ public sealed class HooksCommand(string hookName)
     private static int UnknownHook(string name)
     {
         Console.Error.WriteLine($"Unknown hook: {name}");
+        Console.Error.WriteLine("Valid hooks: block-dangerous, enforce-commit-msg, auto-lint, log-agent, stop-guard, research-reminder");
         return 1;
     }
 

--- a/tools/setup-cli/InitCommand.cs
+++ b/tools/setup-cli/InitCommand.cs
@@ -22,7 +22,7 @@ public sealed class InitCommand(string targetDir, string? requestedOrg, string p
     {
         var version = Assembly.GetExecutingAssembly().GetName().Version?.ToString(3) ?? "1.0.0";
         Console.WriteLine($"\nmultiagent-setup v{version}");
-        Console.WriteLine($"  Mode:     init (inject into existing repo)");
+        Console.WriteLine($"  Mode:     init (add workspace files to existing repo)");
         Console.WriteLine($"  Target:   {targetDir}");
         Console.WriteLine($"  Provider: {provider}");
         Console.WriteLine();
@@ -34,7 +34,8 @@ public sealed class InitCommand(string targetDir, string? requestedOrg, string p
         if (gitCheckCode != 0)
         {
             Console.Error.WriteLine($"Error: {targetDir} is not a git repository.");
-            Console.Error.WriteLine("       Use 'multiagent-setup new <name>' to create a new workspace.");
+            Console.Error.WriteLine("       Run `git init` first, then re-run `multiagent-setup init`.");
+            Console.Error.WriteLine("       Or use `multiagent-setup new <name>` to create a new workspace from scratch.");
             return 1;
         }
 
@@ -51,7 +52,7 @@ public sealed class InitCommand(string targetDir, string? requestedOrg, string p
 
         var graphName = $"{projectName.ToLower()}-ops";
 
-        Console.WriteLine("Injecting workspace files...");
+        Console.WriteLine("Adding workspace files...");
         Console.WriteLine($"  Project:    {projectName}");
         Console.WriteLine($"  GitHub org: {org}");
         Console.WriteLine($"  Graph:      {graphName}");
@@ -371,7 +372,7 @@ public sealed class InitCommand(string targetDir, string? requestedOrg, string p
     private static async Task SetupAgencyRolesAsync(string workspaceRoot)
     {
         var agencyDir = Path.GetFullPath(Path.Combine(workspaceRoot, "..", "agency-agents"));
-        await new SyncRolesCommand("--clone", agencyDir).ExecuteAsync();
+        await new SyncRolesCommand("--clone", agencyDir, globalSync: false, localSyncDir: workspaceRoot).ExecuteAsync();
     }
 
     // ── Git commit ────────────────────────────────────────────────────────────
@@ -394,7 +395,7 @@ public sealed class InitCommand(string targetDir, string? requestedOrg, string p
         }
 
         var (commitCode, _, commitErr) = await ProcessHelper.RunAsync(
-            "git", ["commit", "-q", "-m", "chore: add multiagent workspace setup"],
+            "git", ["-c", "commit.gpgsign=false", "commit", "-q", "-m", "chore: add multiagent workspace setup"],
             workingDir: root, captureOutput: true);
         if (commitCode != 0) throw new InvalidOperationException($"git commit failed: {commitErr}");
     }

--- a/tools/setup-cli/InitCommand.cs
+++ b/tools/setup-cli/InitCommand.cs
@@ -4,7 +4,7 @@ using System.Text;
 
 namespace MultiagentSetup;
 
-public sealed class InitCommand(string targetDir, string? requestedOrg, string provider = "claude", bool force = false)
+public sealed class InitCommand(string targetDir, string? requestedOrg, string provider = "claude", bool force = false, string template = "default")
 {
     // Resource names for provider-specific workspace instruction files
     // (in init mode, the CLAUDE.md template is repurposed as the workspace instructions base)
@@ -68,7 +68,7 @@ public sealed class InitCommand(string targetDir, string? requestedOrg, string p
         CreateDirectories(targetDir, providers);
 
         var vars = BuildVars(projectName, org, graphName);
-        ExtractTemplates(targetDir, vars, providers);
+        ExtractTemplates(targetDir, vars, providers, template);
         Console.WriteLine("  OK: templates extracted");
 
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
@@ -258,11 +258,25 @@ public sealed class InitCommand(string targetDir, string? requestedOrg, string p
         ["{{HOOK_EXEC}}"]           = TemplateResources.ResolveHookExec(),
     };
 
-    private void ExtractTemplates(string root, Dictionary<string, string> vars, string[] providers)
+    private void ExtractTemplates(string root, Dictionary<string, string> vars, string[] providers, string templateName)
     {
         var asm = Assembly.GetExecutingAssembly();
+
+        // Build variant override map: default resource name → variant resource name
+        var variantOverrides = new Dictionary<string, string>(StringComparer.Ordinal);
+        if (templateName != "default")
+        {
+            var prefix = $"variant/{templateName}/";
+            foreach (var res in asm.GetManifestResourceNames())
+                if (res.StartsWith(prefix, StringComparison.Ordinal))
+                    variantOverrides[res[prefix.Length..]] = res;
+        }
+
         foreach (var resourceName in asm.GetManifestResourceNames())
         {
+            // Skip variant resources — used only via overrides
+            if (resourceName.StartsWith("variant/", StringComparison.Ordinal)) continue;
+
             var outputRel = ResolveOutputPathForInit(resourceName, providers);
             if (outputRel is null) continue;
 
@@ -275,11 +289,15 @@ public sealed class InitCommand(string targetDir, string? requestedOrg, string p
                 continue;
             }
 
+            // Use variant override if available for this resource
+            var effectiveResource = variantOverrides.TryGetValue(resourceName, out var variantRes)
+                ? variantRes : resourceName;
+
             Directory.CreateDirectory(Path.GetDirectoryName(outputPath)!);
 
-            using var stream = asm.GetManifestResourceStream(resourceName)!;
+            using var stream = asm.GetManifestResourceStream(effectiveResource)!;
 
-            if (TemplateResources.IsTextResource(resourceName))
+            if (TemplateResources.IsTextResource(effectiveResource))
             {
                 using var reader = new StreamReader(stream, Encoding.UTF8);
                 var content = reader.ReadToEnd();

--- a/tools/setup-cli/ListProvidersCommand.cs
+++ b/tools/setup-cli/ListProvidersCommand.cs
@@ -16,20 +16,36 @@ public sealed class ListProvidersCommand
 
         Console.WriteLine($"\nProviders in: {cwd}\n");
 
+        var installed  = new List<string>();
+        var available  = new List<string>();
+
         foreach (var def in ProviderRegistry.All)
         {
-            var detected = IsProviderDetected(cwd, def);
-            var marker   = detected ? "[+]" : "[ ]";
-            Console.Write($"  {marker} {def.Name,-12}");
-            if (detected && def.WorkspaceInstructionsFile is not null)
-                Console.WriteLine($"  {def.WorkspaceInstructionsFile}");
+            if (IsProviderDetected(cwd, def))
+            {
+                installed.Add(def.Name);
+                Console.Write($"  [installed] {def.Name,-12}");
+                if (def.WorkspaceInstructionsFile is not null)
+                    Console.WriteLine($"  {def.WorkspaceInstructionsFile}");
+                else
+                    Console.WriteLine();
+            }
             else
-                Console.WriteLine();
+            {
+                available.Add(def.Name);
+            }
+        }
+
+        if (available.Count > 0)
+        {
+            Console.WriteLine();
+            Console.WriteLine($"  [available] {string.Join(", ", available)}");
         }
 
         Console.WriteLine();
+        if (installed.Count > 0)
+            Console.WriteLine("To remove a provider: multiagent-setup remove-provider <name>");
         Console.WriteLine("To add a provider:    multiagent-setup add-provider <name>");
-        Console.WriteLine("To remove a provider: multiagent-setup remove-provider <name>");
         Console.WriteLine();
 
         return Task.FromResult(0);

--- a/tools/setup-cli/ListProvidersCommand.cs
+++ b/tools/setup-cli/ListProvidersCommand.cs
@@ -1,0 +1,49 @@
+namespace MultiagentSetup;
+
+public sealed class ListProvidersCommand
+{
+    public Task<int> ExecuteAsync()
+    {
+        var cwd = Directory.GetCurrentDirectory();
+
+        if (!File.Exists(Path.Combine(cwd, "CLAUDE.md")) ||
+            !File.Exists(Path.Combine(cwd, "docs", "process.md")))
+        {
+            Console.Error.WriteLine("Error: not in a multiagent workspace (CLAUDE.md or docs/process.md not found)");
+            Console.Error.WriteLine("Run this command from the workspace root directory.");
+            return Task.FromResult(1);
+        }
+
+        Console.WriteLine($"\nProviders in: {cwd}\n");
+
+        foreach (var def in ProviderRegistry.All)
+        {
+            var detected = IsProviderDetected(cwd, def);
+            var marker   = detected ? "[+]" : "[ ]";
+            Console.Write($"  {marker} {def.Name,-12}");
+            if (detected && def.WorkspaceInstructionsFile is not null)
+                Console.WriteLine($"  {def.WorkspaceInstructionsFile}");
+            else
+                Console.WriteLine();
+        }
+
+        Console.WriteLine();
+        Console.WriteLine("To add a provider:    multiagent-setup add-provider <name>");
+        Console.WriteLine("To remove a provider: multiagent-setup remove-provider <name>");
+        Console.WriteLine();
+
+        return Task.FromResult(0);
+    }
+
+    private static bool IsProviderDetected(string root, ProviderDef def)
+    {
+        if (def.Detection.DetectFile is not null)
+            return File.Exists(Path.Combine(root, def.Detection.DetectFile.Replace('/', Path.DirectorySeparatorChar)));
+        if (def.Detection.DetectDir is not null)
+            return Directory.Exists(Path.Combine(root, def.Detection.DetectDir.Replace('/', Path.DirectorySeparatorChar)));
+        // Fallback for providers with DetectionHint.Never (e.g. nessy): check instructions file
+        if (def.WorkspaceInstructionsFile is not null)
+            return File.Exists(Path.Combine(root, def.WorkspaceInstructionsFile));
+        return false;
+    }
+}

--- a/tools/setup-cli/MultiagentSetup.csproj
+++ b/tools/setup-cli/MultiagentSetup.csproj
@@ -90,6 +90,13 @@
     <!-- Provider: Roo Code -->
     <EmbeddedResource Include="Templates/providers/roo/.roo/rules/workspace.md" LogicalName="providers/roo/.roo/rules/workspace.md" />
 
+    <!-- Provider: Kiro (Amazon) -->
+    <EmbeddedResource Include="Templates/providers/kiro/.kiro/steering/workspace.md" LogicalName="providers/kiro/.kiro/steering/workspace.md" />
+
+    <!-- CI workflows for additional providers -->
+    <EmbeddedResource Include="Templates/providers/gemini/.github/workflows/orchestrator-gemini.yml" LogicalName="providers/gemini/.github/workflows/orchestrator-gemini.yml" />
+    <EmbeddedResource Include="Templates/providers/codex/.github/workflows/orchestrator-codex.yml" LogicalName="providers/codex/.github/workflows/orchestrator-codex.yml" />
+
     <!-- Template variants -->
     <EmbeddedResource Include="Templates/variants/saas/docs/process.md" LogicalName="variant/saas/docs/process.md" />
     <EmbeddedResource Include="Templates/variants/oss/docs/process.md" LogicalName="variant/oss/docs/process.md" />

--- a/tools/setup-cli/MultiagentSetup.csproj
+++ b/tools/setup-cli/MultiagentSetup.csproj
@@ -7,7 +7,7 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>multiagent-setup</ToolCommandName>
     <PackageId>multiagent-setup</PackageId>
-    <Version>1.32.0</Version>
+    <Version>1.33.0</Version>
     <Description>Scaffold a multi-agent AI workspace (Claude, Nessy, Gemini, Codex, Qwen, Aider, Cline, Roo Code, Continue, Cursor, Windsurf, Copilot)</Description>
     <Authors>Roman Melnikov</Authors>
     <PackageTags>claude;nessy;gemini;codex;qwen;aider;cline;roo;continue;cursor;windsurf;copilot;ai;multiagent;workspace;orchestrator;developer-tools;agents</PackageTags>

--- a/tools/setup-cli/MultiagentSetup.csproj
+++ b/tools/setup-cli/MultiagentSetup.csproj
@@ -23,6 +23,7 @@
   <ItemGroup>
     <!-- Root docs -->
     <EmbeddedResource Include="Templates/CLAUDE.md" LogicalName="CLAUDE.md" />
+    <EmbeddedResource Include="Templates/CHANGELOG.md" LogicalName="CHANGELOG.md" />
 
     <!-- Docs -->
     <EmbeddedResource Include="Templates/docs/process.md" LogicalName="docs/process.md" />

--- a/tools/setup-cli/MultiagentSetup.csproj
+++ b/tools/setup-cli/MultiagentSetup.csproj
@@ -7,7 +7,7 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>multiagent-setup</ToolCommandName>
     <PackageId>multiagent-setup</PackageId>
-    <Version>1.31.0</Version>
+    <Version>1.32.0</Version>
     <Description>Scaffold a multi-agent AI workspace (Claude, Nessy, Gemini, Codex, Qwen, Aider, Cline, Roo Code, Continue, Cursor, Windsurf, Copilot)</Description>
     <Authors>Roman Melnikov</Authors>
     <PackageTags>claude;nessy;gemini;codex;qwen;aider;cline;roo;continue;cursor;windsurf;copilot;ai;multiagent;workspace;orchestrator;developer-tools;agents</PackageTags>

--- a/tools/setup-cli/MultiagentSetup.csproj
+++ b/tools/setup-cli/MultiagentSetup.csproj
@@ -90,6 +90,11 @@
     <!-- Provider: Roo Code -->
     <EmbeddedResource Include="Templates/providers/roo/.roo/rules/workspace.md" LogicalName="providers/roo/.roo/rules/workspace.md" />
 
+    <!-- Template variants -->
+    <EmbeddedResource Include="Templates/variants/saas/docs/process.md" LogicalName="variant/saas/docs/process.md" />
+    <EmbeddedResource Include="Templates/variants/oss/docs/process.md" LogicalName="variant/oss/docs/process.md" />
+    <EmbeddedResource Include="Templates/variants/internal/docs/process.md" LogicalName="variant/internal/docs/process.md" />
+
     <!-- Tool scripts -->
     <EmbeddedResource Include="Templates/tools/sync-roles.sh" LogicalName="tools/sync-roles.sh" />
     <EmbeddedResource Include="Templates/tools/sync-roles.ps1" LogicalName="tools/sync-roles.ps1" />

--- a/tools/setup-cli/Program.cs
+++ b/tools/setup-cli/Program.cs
@@ -21,7 +21,7 @@ return args[0] switch
     "sync-roles"       => await HandleSyncRoles(args[1..]),
     "install-mcps"     => await new InstallMcpsCommand(args[1..]).ExecuteAsync(),
     "hook"             => await HandleHook(args[1..]),
-    "doctor"           => await new DoctorCommand().ExecuteAsync(),
+    "doctor"           => await HandleDoctor(args[1..]),
     _ when !args[0].StartsWith('-') => await HandleNew(args), // backward compat
     _ => PrintUsage(error: $"Unknown command: {args[0]}")
 };
@@ -33,14 +33,20 @@ async Task<int> HandleNew(string[] a)
 
     string? org      = null;
     string? provider = null;  // null = not specified by user
+    string? template = null;
 
     for (int i = 1; i < a.Length; i++)
     {
         if (a[i] == "--provider" && i + 1 < a.Length)
             provider = a[++i];
+        else if (a[i] == "--template" && i + 1 < a.Length)
+            template = a[++i];
         else if (!a[i].StartsWith('-'))
             org ??= a[i];
     }
+
+    if (template is not null && template != "default")
+        Console.WriteLine($"  INFO: template '{template}' not yet available — using 'default'. Track: https://github.com/Neftedollar/multiagent-template/issues/111");
 
     // Interactive provider picker when not specified and stdin is a terminal
     if (provider is null && !Console.IsInputRedirected)
@@ -59,17 +65,23 @@ async Task<int> HandleInit(string[] a)
     string? dir      = null;
     string? org      = null;
     string? provider = null;
+    string? template = null;
     bool    force    = false;
 
     for (int i = 0; i < a.Length; i++)
     {
         if (a[i] == "--provider" && i + 1 < a.Length)
             provider = a[++i];
+        else if (a[i] == "--template" && i + 1 < a.Length)
+            template = a[++i];
         else if (a[i] == "--force")
             force = true;
         else if (!a[i].StartsWith('-'))
             dir ??= a[i];
     }
+
+    if (template is not null && template != "default")
+        Console.WriteLine($"  INFO: template '{template}' not yet available — using 'default'. Track: https://github.com/Neftedollar/multiagent-template/issues/111");
 
     dir = Path.GetFullPath(dir ?? Directory.GetCurrentDirectory());
 
@@ -141,6 +153,14 @@ Task<int> HandleUpdate(string[] a)
     return new UpdateCommand(force).ExecuteAsync();
 }
 
+Task<int> HandleDoctor(string[] a)
+{
+    string? forCmd = null;
+    for (int i = 0; i < a.Length - 1; i++)
+        if (a[i] == "--for") forCmd = a[i + 1];
+    return new DoctorCommand(forCommand: forCmd).ExecuteAsync();
+}
+
 async Task<int> HandleHook(string[] a)
 {
     var name = a.ElementAtOrDefault(0);
@@ -169,10 +189,12 @@ static int PrintUsage(string? error = null)
     Console.WriteLine("  new <project-name> [github-org]    Create a new multi-agent workspace");
     Console.WriteLine($"    --provider <name>                 Provider: claude (default), or:");
     Console.WriteLine($"                                       {allNames}");
+    Console.WriteLine("    --template <name>                 Workspace template: default (only option currently)");
     Console.WriteLine("  init [dir]                          Add workspace files to an existing git repo (does not touch your code)");
     Console.WriteLine("    dir                               Target directory — must already be a git repo (default: current)");
     Console.WriteLine($"    --provider <name>                 Provider: claude (default), or:");
     Console.WriteLine($"                                       {allNames}");
+    Console.WriteLine("    --template <name>                 Workspace template: default (only option currently)");
     Console.WriteLine("    --force                           Overwrite existing files");
     Console.WriteLine("  add-provider <name>                 Add a provider to an existing workspace");
     Console.WriteLine($"    <name>: {addNames}");
@@ -195,6 +217,7 @@ static int PrintUsage(string? error = null)
     Console.WriteLine("  hook <name>                         Run a hook (cross-platform)");
     Console.WriteLine("    block-dangerous | enforce-commit-msg | auto-lint | log-agent | stop-guard");
     Console.WriteLine("  doctor                              Check workspace health (tools, files, hooks)");
+    Console.WriteLine("    --for <command>                   Pre-flight check for a specific command (sync-roles, init, update)");
     Console.WriteLine();
     Console.WriteLine("Options:");
     Console.WriteLine("  -h, --help                          Show this help");

--- a/tools/setup-cli/Program.cs
+++ b/tools/setup-cli/Program.cs
@@ -96,15 +96,24 @@ async Task<int> HandleAddProvider(string[] a)
 
     if (provider == "all")
     {
+        var errors = new List<string>();
         foreach (var p in ProviderRegistry.ValidForAdd.Where(n => n != "all"))
         {
             var r = await new AddProviderCommand(p, force).ExecuteAsync();
-            if (r != 0) return r;
+            if (r != 0) errors.Add(p);
+        }
+        if (errors.Count > 0)
+        {
+            Console.Error.WriteLine($"  WARN: Failed providers: {string.Join(", ", errors)}");
+            return 1;
         }
         return 0;
     }
 
-    if (provider == "claude" || ProviderRegistry.Find(provider) is null)
+    if (provider == "claude")
+        return PrintUsage(error: "Provider 'claude' is included in 'new' and cannot be added separately.\n       Use: multiagent-setup add-provider <other-provider>");
+
+    if (ProviderRegistry.Find(provider) is null)
         return PrintUsage(error: $"Unknown provider '{provider}'. Valid: {string.Join(", ", ProviderRegistry.ValidForAdd)}");
 
     return await new AddProviderCommand(provider, force).ExecuteAsync();
@@ -125,11 +134,12 @@ async Task<int> HandleHook(string[] a)
 
 async Task<int> HandleSyncRoles(string[] a)
 {
-    var action = a.FirstOrDefault(x => x is "--clone" or "--pull") ?? "--pull";
+    var action  = a.FirstOrDefault(x => x is "--clone" or "--pull") ?? "--pull";
+    bool global = a.Contains("--global");
     string? agDir = null;
     for (int i = 0; i < a.Length - 1; i++)
         if (a[i] == "--agency-dir") agDir = a[i + 1];
-    return await new SyncRolesCommand(action, agDir).ExecuteAsync();
+    return await new SyncRolesCommand(action, agDir, globalSync: global).ExecuteAsync();
 }
 
 static int PrintUsage(string? error = null)
@@ -143,8 +153,8 @@ static int PrintUsage(string? error = null)
     Console.WriteLine("  new <project-name> [github-org]    Create a new multi-agent workspace");
     Console.WriteLine($"    --provider <name>                 Provider: claude (default), or:");
     Console.WriteLine($"                                       {allNames}");
-    Console.WriteLine("  init [dir]                          Inject workspace files into an existing git repo");
-    Console.WriteLine("    dir                               Target directory (default: current directory)");
+    Console.WriteLine("  init [dir]                          Add workspace files to an existing git repo (does not touch your code)");
+    Console.WriteLine("    dir                               Target directory — must already be a git repo (default: current)");
     Console.WriteLine($"    --provider <name>                 Provider: claude (default), or:");
     Console.WriteLine($"                                       {allNames}");
     Console.WriteLine("    --force                           Overwrite existing files");
@@ -153,7 +163,8 @@ static int PrintUsage(string? error = null)
     Console.WriteLine("    --force                           Overwrite existing provider config");
     Console.WriteLine("  update                              Update workspace templates to latest version");
     Console.WriteLine("    --force                           Overwrite all files (CLAUDE.md preserved by default)");
-    Console.WriteLine("  sync-roles [--clone|--pull]         Sync agent roles to ~/.claude/commands/");
+    Console.WriteLine("  sync-roles [--clone|--pull]         Sync agent roles to local .claude/commands/");
+    Console.WriteLine("    --global                          Also sync to ~/.claude/commands/ globally");
     Console.WriteLine("    --agency-dir <path>               Override agency-agents directory");
     Console.WriteLine("  install-mcps [options]              Install age-mcp and o-brien MCP servers");
     Console.WriteLine("    --docker                          Use local Docker (default, interactive)");

--- a/tools/setup-cli/Program.cs
+++ b/tools/setup-cli/Program.cs
@@ -19,7 +19,7 @@ return args[0] switch
     "list-providers"   => await new ListProvidersCommand().ExecuteAsync(),
     "update"           => await HandleUpdate(args[1..]),
     "sync-roles"       => await HandleSyncRoles(args[1..]),
-    "install-mcps"     => await new InstallMcpsCommand(args[1..]).ExecuteAsync(),
+    "install-mcps"     => await HandleInstallMcps(args[1..]),
     "hook"             => await HandleHook(args[1..]),
     "doctor"           => await HandleDoctor(args[1..]),
     _ when !args[0].StartsWith('-') => await HandleNew(args), // backward compat
@@ -166,12 +166,19 @@ Task<int> HandleDoctor(string[] a)
 async Task<int> HandleHook(string[] a)
 {
     var name = a.ElementAtOrDefault(0);
-    if (name is null) return PrintUsage(error: "hook name is required");
+    if (name is null || name is "--help" or "-h") return PrintUsage(name is null ? "hook name is required" : null);
     return await new HooksCommand(name).ExecuteAsync();
+}
+
+async Task<int> HandleInstallMcps(string[] a)
+{
+    if (a.Contains("--help") || a.Contains("-h")) return PrintUsage();
+    return await new InstallMcpsCommand(a).ExecuteAsync();
 }
 
 async Task<int> HandleSyncRoles(string[] a)
 {
+    if (a.Contains("--help") || a.Contains("-h")) return PrintUsage();
     var action  = a.FirstOrDefault(x => x is "--clone" or "--pull") ?? "--pull";
     bool global = a.Contains("--global");
     string? agDir = null;
@@ -217,7 +224,7 @@ static int PrintUsage(string? error = null)
     Console.WriteLine("    --obrien-conn <str>               O'Brien connection string");
     Console.WriteLine("    --target <dir>                    Target dir for age-mcp clone");
     Console.WriteLine("  hook <name>                         Run a hook (cross-platform)");
-    Console.WriteLine("    block-dangerous | enforce-commit-msg | auto-lint | log-agent | stop-guard");
+    Console.WriteLine("    block-dangerous | enforce-commit-msg | auto-lint | log-agent | stop-guard | research-reminder");
     Console.WriteLine("  doctor                              Check workspace health (tools, files, hooks)");
     Console.WriteLine("    --for <command>                   Pre-flight check for a specific command (sync-roles, init, update)");
     Console.WriteLine();

--- a/tools/setup-cli/Program.cs
+++ b/tools/setup-cli/Program.cs
@@ -12,14 +12,16 @@ if (args[0] is "-v" or "--version")
 
 return args[0] switch
 {
-    "new"           => await HandleNew(args[1..]),
-    "init"          => await HandleInit(args[1..]),
-    "add-provider"  => await HandleAddProvider(args[1..]),
-    "update"        => await HandleUpdate(args[1..]),
-    "sync-roles"    => await HandleSyncRoles(args[1..]),
-    "install-mcps"  => await new InstallMcpsCommand(args[1..]).ExecuteAsync(),
-    "hook"          => await HandleHook(args[1..]),
-    "doctor"        => await new DoctorCommand().ExecuteAsync(),
+    "new"              => await HandleNew(args[1..]),
+    "init"             => await HandleInit(args[1..]),
+    "add-provider"     => await HandleAddProvider(args[1..]),
+    "remove-provider"  => await HandleRemoveProvider(args[1..]),
+    "list-providers"   => await new ListProvidersCommand().ExecuteAsync(),
+    "update"           => await HandleUpdate(args[1..]),
+    "sync-roles"       => await HandleSyncRoles(args[1..]),
+    "install-mcps"     => await new InstallMcpsCommand(args[1..]).ExecuteAsync(),
+    "hook"             => await HandleHook(args[1..]),
+    "doctor"           => await new DoctorCommand().ExecuteAsync(),
     _ when !args[0].StartsWith('-') => await HandleNew(args), // backward compat
     _ => PrintUsage(error: $"Unknown command: {args[0]}")
 };
@@ -84,6 +86,20 @@ async Task<int> HandleInit(string[] a)
         return PrintUsage(error: $"Unknown provider '{provider}'. Valid: {string.Join(", ", ProviderRegistry.ValidForNew)}");
 
     return await new InitCommand(dir, org, provider, force).ExecuteAsync();
+}
+
+async Task<int> HandleRemoveProvider(string[] a)
+{
+    var provider = a.ElementAtOrDefault(0);
+    if (provider is null || provider.StartsWith('-'))
+        return PrintUsage(error: "provider name is required");
+
+    bool force = a.Contains("--force");
+
+    if (ProviderRegistry.Find(provider) is null && provider != "claude")
+        return PrintUsage(error: $"Unknown provider '{provider}'. Valid: {string.Join(", ", ProviderRegistry.ValidForAdd)}");
+
+    return await new RemoveProviderCommand(provider, force).ExecuteAsync();
 }
 
 async Task<int> HandleAddProvider(string[] a)
@@ -161,6 +177,10 @@ static int PrintUsage(string? error = null)
     Console.WriteLine("  add-provider <name>                 Add a provider to an existing workspace");
     Console.WriteLine($"    <name>: {addNames}");
     Console.WriteLine("    --force                           Overwrite existing provider config");
+    Console.WriteLine("  remove-provider <name>              Remove a provider from an existing workspace");
+    Console.WriteLine($"    <name>: {addNames}");
+    Console.WriteLine("    --force                           Skip confirmation prompt");
+    Console.WriteLine("  list-providers                      List providers configured in current workspace");
     Console.WriteLine("  update                              Update workspace templates to latest version");
     Console.WriteLine("    --force                           Overwrite all files (CLAUDE.md preserved by default)");
     Console.WriteLine("  sync-roles [--clone|--pull]         Sync agent roles to local .claude/commands/");

--- a/tools/setup-cli/Program.cs
+++ b/tools/setup-cli/Program.cs
@@ -22,6 +22,7 @@ return args[0] switch
     "install-mcps"     => await HandleInstallMcps(args[1..]),
     "hook"             => await HandleHook(args[1..]),
     "doctor"           => await HandleDoctor(args[1..]),
+    "completions"      => await HandleCompletions(args[1..]),
     _ when !args[0].StartsWith('-') => await HandleNew(args), // backward compat
     _ => PrintUsage(error: $"Unknown command: {args[0]}")
 };
@@ -108,12 +109,13 @@ async Task<int> HandleRemoveProvider(string[] a)
     if (provider is null || provider.StartsWith('-'))
         return PrintUsage(error: "provider name is required");
 
-    bool force = a.Contains("--force");
+    bool force  = a.Contains("--force");
+    bool dryRun = a.Contains("--dry-run");
 
     if (ProviderRegistry.Find(provider) is null && provider != "claude")
         return PrintUsage(error: $"Unknown provider '{provider}'. Valid: {string.Join(", ", ProviderRegistry.ValidForAdd)}");
 
-    return await new RemoveProviderCommand(provider, force).ExecuteAsync();
+    return await new RemoveProviderCommand(provider, force, dryRun).ExecuteAsync();
 }
 
 async Task<int> HandleAddProvider(string[] a)
@@ -151,8 +153,9 @@ async Task<int> HandleAddProvider(string[] a)
 
 Task<int> HandleUpdate(string[] a)
 {
-    bool force = a.Contains("--force");
-    return new UpdateCommand(force).ExecuteAsync();
+    bool force  = a.Contains("--force");
+    bool dryRun = a.Contains("--dry-run");
+    return new UpdateCommand(force, dryRun).ExecuteAsync();
 }
 
 Task<int> HandleDoctor(string[] a)
@@ -174,6 +177,26 @@ async Task<int> HandleInstallMcps(string[] a)
 {
     if (a.Contains("--help") || a.Contains("-h")) return PrintUsage();
     return await new InstallMcpsCommand(a).ExecuteAsync();
+}
+
+async Task<int> HandleCompletions(string[] a)
+{
+    var shell = a.ElementAtOrDefault(0);
+    if (shell is null || shell is "--help" or "-h")
+    {
+        Console.WriteLine("Usage: multiagent-setup completions <shell>");
+        Console.WriteLine();
+        Console.WriteLine("Shells:");
+        Console.WriteLine("  zsh   — zsh completion script");
+        Console.WriteLine("  pwsh  — PowerShell completion script");
+        Console.WriteLine();
+        Console.WriteLine("Examples:");
+        Console.WriteLine("  eval \"$(multiagent-setup completions zsh)\"");
+        Console.WriteLine("  multiagent-setup completions zsh >> ~/.zshrc");
+        Console.WriteLine("  multiagent-setup completions pwsh >> $PROFILE");
+        return shell is null ? 1 : 0;
+    }
+    return await new CompletionsCommand(shell).ExecuteAsync();
 }
 
 async Task<int> HandleSyncRoles(string[] a)
@@ -211,9 +234,11 @@ static int PrintUsage(string? error = null)
     Console.WriteLine("  remove-provider <name>              Remove a provider from an existing workspace");
     Console.WriteLine($"    <name>: {addNames}");
     Console.WriteLine("    --force                           Skip confirmation prompt");
+    Console.WriteLine("    --dry-run                         Preview what would be removed without deleting");
     Console.WriteLine("  list-providers                      List providers configured in current workspace");
     Console.WriteLine("  update                              Update workspace templates to latest version");
     Console.WriteLine("    --force                           Overwrite all files (CLAUDE.md preserved by default)");
+    Console.WriteLine("    --dry-run                         Preview what would be updated without writing");
     Console.WriteLine("  sync-roles [--clone|--pull]         Sync agent roles to local .claude/commands/");
     Console.WriteLine("    --global                          Also sync to ~/.claude/commands/ globally");
     Console.WriteLine("    --agency-dir <path>               Override agency-agents directory");
@@ -227,6 +252,7 @@ static int PrintUsage(string? error = null)
     Console.WriteLine("    block-dangerous | enforce-commit-msg | auto-lint | log-agent | stop-guard | research-reminder");
     Console.WriteLine("  doctor                              Check workspace health (tools, files, hooks)");
     Console.WriteLine("    --for <command>                   Pre-flight check for a specific command (sync-roles, init, update)");
+    Console.WriteLine("  completions <shell>                 Print shell completion script (zsh, pwsh)");
     Console.WriteLine();
     Console.WriteLine("Options:");
     Console.WriteLine("  -h, --help                          Show this help");

--- a/tools/setup-cli/Program.cs
+++ b/tools/setup-cli/Program.cs
@@ -45,8 +45,9 @@ async Task<int> HandleNew(string[] a)
             org ??= a[i];
     }
 
-    if (template is not null && template != "default")
-        Console.WriteLine($"  INFO: template '{template}' not yet available — using 'default'. Track: https://github.com/Neftedollar/multiagent-template/issues/111");
+    template ??= "default";
+    if (template is not ("default" or "saas" or "oss" or "internal"))
+        return PrintUsage(error: $"Unknown template '{template}'. Valid: default, saas, oss, internal");
 
     // Interactive provider picker when not specified and stdin is a terminal
     if (provider is null && !Console.IsInputRedirected)
@@ -57,7 +58,7 @@ async Task<int> HandleNew(string[] a)
     if (provider != "all" && ProviderRegistry.Find(provider) is null)
         return PrintUsage(error: $"Unknown provider '{provider}'. Valid: {string.Join(", ", ProviderRegistry.ValidForNew)}");
 
-    return await new SetupCommand(name, org, provider).ExecuteAsync();
+    return await new SetupCommand(name, org, provider, template).ExecuteAsync();
 }
 
 async Task<int> HandleInit(string[] a)
@@ -80,8 +81,9 @@ async Task<int> HandleInit(string[] a)
             dir ??= a[i];
     }
 
-    if (template is not null && template != "default")
-        Console.WriteLine($"  INFO: template '{template}' not yet available — using 'default'. Track: https://github.com/Neftedollar/multiagent-template/issues/111");
+    template ??= "default";
+    if (template is not ("default" or "saas" or "oss" or "internal"))
+        return PrintUsage(error: $"Unknown template '{template}'. Valid: default, saas, oss, internal");
 
     dir = Path.GetFullPath(dir ?? Directory.GetCurrentDirectory());
 
@@ -97,7 +99,7 @@ async Task<int> HandleInit(string[] a)
     if (provider != "all" && ProviderRegistry.Find(provider) is null)
         return PrintUsage(error: $"Unknown provider '{provider}'. Valid: {string.Join(", ", ProviderRegistry.ValidForNew)}");
 
-    return await new InitCommand(dir, org, provider, force).ExecuteAsync();
+    return await new InitCommand(dir, org, provider, force, template).ExecuteAsync();
 }
 
 async Task<int> HandleRemoveProvider(string[] a)
@@ -189,12 +191,12 @@ static int PrintUsage(string? error = null)
     Console.WriteLine("  new <project-name> [github-org]    Create a new multi-agent workspace");
     Console.WriteLine($"    --provider <name>                 Provider: claude (default), or:");
     Console.WriteLine($"                                       {allNames}");
-    Console.WriteLine("    --template <name>                 Workspace template: default (only option currently)");
+    Console.WriteLine("    --template <name>                 Workspace template: default, saas, oss, internal");
     Console.WriteLine("  init [dir]                          Add workspace files to an existing git repo (does not touch your code)");
     Console.WriteLine("    dir                               Target directory — must already be a git repo (default: current)");
     Console.WriteLine($"    --provider <name>                 Provider: claude (default), or:");
     Console.WriteLine($"                                       {allNames}");
-    Console.WriteLine("    --template <name>                 Workspace template: default (only option currently)");
+    Console.WriteLine("    --template <name>                 Workspace template: default, saas, oss, internal");
     Console.WriteLine("    --force                           Overwrite existing files");
     Console.WriteLine("  add-provider <name>                 Add a provider to an existing workspace");
     Console.WriteLine($"    <name>: {addNames}");

--- a/tools/setup-cli/ProviderRegistry.cs
+++ b/tools/setup-cli/ProviderRegistry.cs
@@ -209,6 +209,18 @@ internal static class ProviderRegistry
             IncludedInAll:            true,
             WorkspaceInstructionsFile: null   // instructions embedded in .roo/rules/*.md
         ),
+        new ProviderDef(
+            Name:                     "kiro",
+            TemplatePrefix:           "providers/kiro/",
+            Directories:              [".kiro/steering"],
+            Detection:                DetectionHint.ByDir(".kiro"),
+            ToolCheck:                ToolCheckMode.Info,
+            BinaryName:               null,
+            InstallHint:              "kiro — Amazon Kiro VS Code extension, install from AWS Toolkit marketplace",
+            NextStepTemplate:         "       kiro          → open {cwd} in VS Code with Kiro extension, .kiro/steering/ loads automatically",
+            IncludedInAll:            true,
+            WorkspaceInstructionsFile: null   // instructions embedded in .kiro/steering/workspace.md
+        ),
     };
 
     /// <summary>All provider names valid for --provider flag (including "all").</summary>

--- a/tools/setup-cli/RemoveProviderCommand.cs
+++ b/tools/setup-cli/RemoveProviderCommand.cs
@@ -1,0 +1,141 @@
+namespace MultiagentSetup;
+
+public sealed class RemoveProviderCommand(string provider, bool force = false)
+{
+    public Task<int> ExecuteAsync()
+    {
+        var cwd = Directory.GetCurrentDirectory();
+
+        if (!File.Exists(Path.Combine(cwd, "CLAUDE.md")) ||
+            !File.Exists(Path.Combine(cwd, "docs", "process.md")))
+        {
+            Console.Error.WriteLine("Error: not in a multiagent workspace (CLAUDE.md or docs/process.md not found)");
+            Console.Error.WriteLine("Run this command from the workspace root directory.");
+            return Task.FromResult(1);
+        }
+
+        if (provider == "claude")
+        {
+            Console.Error.WriteLine("Error: cannot remove provider 'claude' (base provider).");
+            Console.Error.WriteLine("       To remove all non-claude providers, remove them individually.");
+            return Task.FromResult(1);
+        }
+
+        var def = ProviderRegistry.Find(provider);
+        if (def is null)
+        {
+            Console.Error.WriteLine($"Error: unknown provider '{provider}'.");
+            Console.Error.WriteLine($"       Valid: {string.Join(", ", ProviderRegistry.ValidForAdd)}");
+            return Task.FromResult(1);
+        }
+
+        if (!IsProviderDetected(cwd, def))
+        {
+            Console.WriteLine($"Provider '{provider}' is not installed in this workspace.");
+            return Task.FromResult(0);
+        }
+
+        if (!force)
+        {
+            if (Console.IsInputRedirected)
+            {
+                Console.Error.WriteLine("Error: running non-interactively — use --force to confirm removal.");
+                return Task.FromResult(1);
+            }
+            Console.Write($"Remove provider '{provider}' from {cwd}? [y/N] ");
+            var key = Console.ReadLine()?.Trim().ToLowerInvariant();
+            if (key != "y" && key != "yes")
+            {
+                Console.WriteLine("Aborted.");
+                return Task.FromResult(0);
+            }
+        }
+
+        // Directories shared by other active providers — don't delete those
+        var otherActiveDirs = new HashSet<string>(
+            ProviderRegistry.All
+                .Where(p => p.Name != provider && IsProviderDetected(cwd, p))
+                .SelectMany(p => p.Directories),
+            StringComparer.OrdinalIgnoreCase);
+
+        var removed = new List<string>();
+        var skipped = new List<string>();
+
+        // Delete exclusive provider directories
+        foreach (var dir in def.Directories)
+        {
+            // Never delete shared infrastructure directories
+            if (dir.StartsWith(".github", StringComparison.OrdinalIgnoreCase) ||
+                dir.StartsWith(".claude", StringComparison.OrdinalIgnoreCase))
+            {
+                skipped.Add($"{dir} (shared infrastructure — remove manually if needed)");
+                continue;
+            }
+
+            if (otherActiveDirs.Contains(dir))
+            {
+                skipped.Add($"{dir} (also used by another provider)");
+                continue;
+            }
+
+            // Delete from the top-level dir of the path
+            var rootSegment = dir.Split('/')[0];
+            var fullPath = Path.Combine(cwd, rootSegment);
+            if (Directory.Exists(fullPath))
+            {
+                Directory.Delete(fullPath, recursive: true);
+                removed.Add(rootSegment + "/");
+            }
+        }
+
+        // Delete the detection file (e.g. .clinerules, .aider.conf.yml, copilot-instructions.md)
+        if (def.Detection.DetectFile is not null)
+        {
+            var detectPath = Path.Combine(cwd, def.Detection.DetectFile.Replace('/', Path.DirectorySeparatorChar));
+            if (File.Exists(detectPath))
+            {
+                File.Delete(detectPath);
+                removed.Add(def.Detection.DetectFile);
+            }
+        }
+
+        // Delete workspace instructions file (GEMINI.md, NESSY.md, etc.)
+        if (def.WorkspaceInstructionsFile is not null)
+        {
+            var instrPath = Path.Combine(cwd, def.WorkspaceInstructionsFile);
+            if (File.Exists(instrPath))
+            {
+                File.Delete(instrPath);
+                removed.Add(def.WorkspaceInstructionsFile);
+            }
+        }
+
+        Console.WriteLine($"\nProvider '{provider}' removed from {cwd}.");
+
+        if (removed.Count > 0)
+        {
+            Console.WriteLine("Removed:");
+            foreach (var r in removed) Console.WriteLine($"  - {r}");
+        }
+
+        if (skipped.Count > 0)
+        {
+            Console.WriteLine("Skipped:");
+            foreach (var s in skipped) Console.WriteLine($"  - {s}");
+        }
+
+        Console.WriteLine();
+        return Task.FromResult(0);
+    }
+
+    private static bool IsProviderDetected(string root, ProviderDef def)
+    {
+        if (def.Detection.DetectFile is not null)
+            return File.Exists(Path.Combine(root, def.Detection.DetectFile.Replace('/', Path.DirectorySeparatorChar)));
+        if (def.Detection.DetectDir is not null)
+            return Directory.Exists(Path.Combine(root, def.Detection.DetectDir.Replace('/', Path.DirectorySeparatorChar)));
+        if (def.WorkspaceInstructionsFile is not null)
+            return File.Exists(Path.Combine(root, def.WorkspaceInstructionsFile));
+        return false;
+    }
+}

--- a/tools/setup-cli/RemoveProviderCommand.cs
+++ b/tools/setup-cli/RemoveProviderCommand.cs
@@ -1,6 +1,6 @@
 namespace MultiagentSetup;
 
-public sealed class RemoveProviderCommand(string provider, bool force = false)
+public sealed class RemoveProviderCommand(string provider, bool force = false, bool dryRun = false)
 {
     public Task<int> ExecuteAsync()
     {
@@ -35,7 +35,7 @@ public sealed class RemoveProviderCommand(string provider, bool force = false)
             return Task.FromResult(0);
         }
 
-        if (!force)
+        if (!force && !dryRun)
         {
             if (Console.IsInputRedirected)
             {
@@ -83,7 +83,7 @@ public sealed class RemoveProviderCommand(string provider, bool force = false)
             var fullPath = Path.Combine(cwd, rootSegment);
             if (Directory.Exists(fullPath))
             {
-                Directory.Delete(fullPath, recursive: true);
+                if (!dryRun) Directory.Delete(fullPath, recursive: true);
                 removed.Add(rootSegment + "/");
             }
         }
@@ -94,7 +94,7 @@ public sealed class RemoveProviderCommand(string provider, bool force = false)
             var detectPath = Path.Combine(cwd, def.Detection.DetectFile.Replace('/', Path.DirectorySeparatorChar));
             if (File.Exists(detectPath))
             {
-                File.Delete(detectPath);
+                if (!dryRun) File.Delete(detectPath);
                 removed.Add(def.Detection.DetectFile);
             }
         }
@@ -105,16 +105,19 @@ public sealed class RemoveProviderCommand(string provider, bool force = false)
             var instrPath = Path.Combine(cwd, def.WorkspaceInstructionsFile);
             if (File.Exists(instrPath))
             {
-                File.Delete(instrPath);
+                if (!dryRun) File.Delete(instrPath);
                 removed.Add(def.WorkspaceInstructionsFile);
             }
         }
 
-        Console.WriteLine($"\nProvider '{provider}' removed from {cwd}.");
+        if (dryRun)
+            Console.WriteLine($"\n[DRY RUN] No changes will be made. Would remove provider '{provider}' from {cwd}.");
+        else
+            Console.WriteLine($"\nProvider '{provider}' removed from {cwd}.");
 
         if (removed.Count > 0)
         {
-            Console.WriteLine("Removed:");
+            Console.WriteLine(dryRun ? "Would remove:" : "Removed:");
             foreach (var r in removed) Console.WriteLine($"  - {r}");
         }
 
@@ -123,6 +126,9 @@ public sealed class RemoveProviderCommand(string provider, bool force = false)
             Console.WriteLine("Skipped:");
             foreach (var s in skipped) Console.WriteLine($"  - {s}");
         }
+
+        if (dryRun)
+            Console.WriteLine("\nDry run complete. No files were modified. Remove --dry-run to apply.");
 
         Console.WriteLine();
         return Task.FromResult(0);

--- a/tools/setup-cli/SetupCommand.cs
+++ b/tools/setup-cli/SetupCommand.cs
@@ -24,7 +24,10 @@ public sealed class SetupCommand(string projectName, string? requestedOrg, strin
         var targetDir = Path.GetFullPath(Path.Combine(Directory.GetCurrentDirectory(), projectName));
         if (Directory.Exists(targetDir))
         {
-            Console.Error.WriteLine($"Error: {targetDir} already exists");
+            Console.Error.WriteLine($"Error: {targetDir} already exists.");
+            Console.Error.WriteLine($"  • To update an existing workspace:  multiagent-setup update");
+            Console.Error.WriteLine($"  • To inject into an existing repo:  multiagent-setup init {targetDir}");
+            Console.Error.WriteLine($"  • To start fresh: delete the directory and re-run");
             return 1;
         }
 
@@ -250,7 +253,7 @@ public sealed class SetupCommand(string projectName, string? requestedOrg, strin
     private static async Task SetupAgencyRolesAsync(string workspaceRoot)
     {
         var agencyDir = Path.GetFullPath(Path.Combine(workspaceRoot, "..", "agency-agents"));
-        await new SyncRolesCommand("--clone", agencyDir).ExecuteAsync();
+        await new SyncRolesCommand("--clone", agencyDir, globalSync: false, localSyncDir: workspaceRoot).ExecuteAsync();
     }
 
     // ── Git init ──────────────────────────────────────────────────────────────
@@ -272,7 +275,7 @@ public sealed class SetupCommand(string projectName, string? requestedOrg, strin
         if (addCode != 0) throw new InvalidOperationException($"git add failed: {addErr}");
 
         var (commitCode, _, commitErr) = await ProcessHelper.RunAsync(
-            "git", ["commit", "-q", "-m", "init: multi-agent workspace from template"],
+            "git", ["-c", "commit.gpgsign=false", "commit", "-q", "-m", "init: multi-agent workspace from template"],
             workingDir: root, captureOutput: true);
         if (commitCode != 0) throw new InvalidOperationException($"git commit failed: {commitErr}");
     }

--- a/tools/setup-cli/SetupCommand.cs
+++ b/tools/setup-cli/SetupCommand.cs
@@ -4,7 +4,7 @@ using System.Text;
 
 namespace MultiagentSetup;
 
-public sealed class SetupCommand(string projectName, string? requestedOrg, string provider = "claude")
+public sealed class SetupCommand(string projectName, string? requestedOrg, string provider = "claude", string template = "default")
 {
     public async Task<int> ExecuteAsync()
     {
@@ -47,7 +47,7 @@ public sealed class SetupCommand(string projectName, string? requestedOrg, strin
         CreateDirectories(targetDir, providers);
 
         var vars = BuildVars(projectName, org, graphName);
-        ExtractTemplates(targetDir, vars, providers);
+        ExtractTemplates(targetDir, vars, providers, template);
         Console.WriteLine("  OK: templates extracted");
 
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
@@ -184,20 +184,38 @@ public sealed class SetupCommand(string projectName, string? requestedOrg, strin
         ["{{HOOK_EXEC}}"]           = TemplateResources.ResolveHookExec(),
     };
 
-    private static void ExtractTemplates(string root, Dictionary<string, string> vars, string[] providers)
+    private static void ExtractTemplates(string root, Dictionary<string, string> vars, string[] providers, string template)
     {
         var asm = Assembly.GetExecutingAssembly();
+
+        // Build variant override map: default resource name → variant resource name
+        var variantOverrides = new Dictionary<string, string>(StringComparer.Ordinal);
+        if (template != "default")
+        {
+            var prefix = $"variant/{template}/";
+            foreach (var res in asm.GetManifestResourceNames())
+                if (res.StartsWith(prefix, StringComparison.Ordinal))
+                    variantOverrides[res[prefix.Length..]] = res;
+        }
+
         foreach (var resourceName in asm.GetManifestResourceNames())
         {
+            // Skip variant resources — used only via overrides
+            if (resourceName.StartsWith("variant/", StringComparison.Ordinal)) continue;
+
             var outputRel = ResolveOutputPath(resourceName, providers);
             if (outputRel is null) continue;
+
+            // Use variant override if available for this resource
+            var effectiveResource = variantOverrides.TryGetValue(resourceName, out var variantRes)
+                ? variantRes : resourceName;
 
             var outputPath = Path.Combine(root, outputRel.Replace('/', Path.DirectorySeparatorChar));
             Directory.CreateDirectory(Path.GetDirectoryName(outputPath)!);
 
-            using var stream = asm.GetManifestResourceStream(resourceName)!;
+            using var stream = asm.GetManifestResourceStream(effectiveResource)!;
 
-            if (TemplateResources.IsTextResource(resourceName))
+            if (TemplateResources.IsTextResource(effectiveResource))
             {
                 using var reader = new StreamReader(stream, Encoding.UTF8);
                 var content = reader.ReadToEnd();

--- a/tools/setup-cli/SyncRolesCommand.cs
+++ b/tools/setup-cli/SyncRolesCommand.cs
@@ -35,7 +35,9 @@ public sealed class SyncRolesCommand(string action, string? agencyDirOverride, b
                     ["clone", AgencyRepo, agencyDir], captureOutput: true, allowFailure: true);
                 if (code != 0)
                 {
-                    Console.Error.WriteLine($"  WARN: could not clone agency-agents — {err.Trim()}");
+                    Console.Error.WriteLine($"  FAIL: could not clone agency-agents — {err.Trim()}");
+                    Console.Error.WriteLine($"        Try: git clone {AgencyRepo} --depth 1 {agencyDir}");
+                    Console.Error.WriteLine( "        Or:  multiagent-setup sync-roles --pull  (if already cloned manually)");
                     return 1;
                 }
                 Console.WriteLine("  OK: agency-agents cloned");
@@ -53,7 +55,11 @@ public sealed class SyncRolesCommand(string action, string? agencyDirOverride, b
             Console.WriteLine("Pulling latest roles...");
             var (code, _, _) = await ProcessHelper.RunAsync("git", ["pull", "--ff-only"],
                 workingDir: agencyDir, captureOutput: true, allowFailure: true);
-            if (code != 0) Console.WriteLine("  WARN: git pull failed, using existing");
+            if (code != 0)
+            {
+                Console.WriteLine($"  WARN: git pull failed — syncing with existing roles in {agencyDir}");
+                Console.WriteLine($"        To retry: cd {agencyDir} && git pull --ff-only");
+            }
         }
 
         if (!Directory.Exists(agencyDir))

--- a/tools/setup-cli/SyncRolesCommand.cs
+++ b/tools/setup-cli/SyncRolesCommand.cs
@@ -2,7 +2,7 @@ using System.Text;
 
 namespace MultiagentSetup;
 
-public sealed class SyncRolesCommand(string action, string? agencyDirOverride)
+public sealed class SyncRolesCommand(string action, string? agencyDirOverride, bool globalSync = false, string? localSyncDir = null)
 {
     private const string AgencyRepo = "https://github.com/msitarzewski/agency-agents.git";
     private const string Marker     = "<!-- auto-generated from agency-agents -->";
@@ -97,24 +97,57 @@ $ARGUMENTS
         }
 
         // ── Sync targets ───────────────────────────────────────────────────────
-        var cwd = Directory.GetCurrentDirectory();
+        var cwd = localSyncDir ?? Directory.GetCurrentDirectory();
 
-        // Claude / Nessy — global ~/.claude/commands/
-        var (claudeCount, claudeSkipped) = await SyncToDirectoryAsync(
-            roles, globalCommandsDir,
-            projectOverrideDir: Path.Combine(cwd, ".claude", "commands"));
-        Console.WriteLine();
-        Console.WriteLine($"Synced {claudeCount} roles to {globalCommandsDir}");
-        if (claudeSkipped > 0) Console.WriteLine($"Skipped {claudeSkipped} (project-level override exists)");
+        // Claude / Nessy — local .claude/commands/ by default; global only with --global
+        var localClaudeDir = Path.Combine(cwd, ".claude", "commands");
+        var hasLocalClaude = Directory.Exists(Path.GetDirectoryName(localClaudeDir)!); // .claude/ exists
+
+        if (hasLocalClaude)
+        {
+            var (localCount, localSkipped, localSkippedNames) = await SyncToDirectoryAsync(
+                roles, localClaudeDir, projectOverrideDir: localClaudeDir);
+            Console.WriteLine();
+            Console.WriteLine($"Synced {localCount} roles to {localClaudeDir}");
+            if (localSkipped > 0)
+            {
+                Console.WriteLine($"Skipped {localSkipped} roles (project-level override takes precedence):");
+                Console.WriteLine($"  {string.Join(", ", localSkippedNames)}");
+            }
+        }
+
+        if (globalSync)
+        {
+            var overrideDir = hasLocalClaude ? localClaudeDir : Path.Combine(cwd, ".claude", "commands");
+            var (claudeCount, claudeSkipped, claudeSkippedNames) = await SyncToDirectoryAsync(
+                roles, globalCommandsDir, projectOverrideDir: overrideDir);
+            Console.WriteLine();
+            Console.WriteLine($"Synced {claudeCount} roles to {globalCommandsDir}");
+            if (claudeSkipped > 0)
+            {
+                Console.WriteLine($"Skipped {claudeSkipped} roles (project-level override takes precedence):");
+                Console.WriteLine($"  {string.Join(", ", claudeSkippedNames)}");
+            }
+        }
+
+        if (!hasLocalClaude && !globalSync)
+        {
+            Console.Error.WriteLine($"  WARN: no local .claude/ workspace found in {cwd}");
+            Console.Error.WriteLine($"  Use --global to sync to ~/.claude/commands/");
+        }
 
         // Qwen — workspace-level (auto-detected)
         var qwenDir = Path.Combine(cwd, ".qwen", "commands");
         if (Directory.Exists(Path.GetDirectoryName(qwenDir)!))
         {
             Directory.CreateDirectory(qwenDir);
-            var (qCount, qSkipped) = await SyncToDirectoryAsync(roles, qwenDir, projectOverrideDir: qwenDir);
+            var (qCount, qSkipped, qSkippedNames) = await SyncToDirectoryAsync(roles, qwenDir, projectOverrideDir: qwenDir);
             Console.WriteLine($"Synced {qCount} roles to {qwenDir} (qwen)");
-            if (qSkipped > 0) Console.WriteLine($"Skipped {qSkipped} (existing override)");
+            if (qSkipped > 0)
+            {
+                Console.WriteLine($"Skipped {qSkipped} roles (project-level override takes precedence):");
+                Console.WriteLine($"  {string.Join(", ", qSkippedNames)}");
+            }
         }
 
         // Codex — workspace-level (auto-detected)
@@ -122,18 +155,23 @@ $ARGUMENTS
         if (Directory.Exists(Path.GetDirectoryName(codexDir)!))
         {
             Directory.CreateDirectory(codexDir);
-            var (cCount, cSkipped) = await SyncToDirectoryAsync(roles, codexDir, projectOverrideDir: codexDir);
+            var (cCount, cSkipped, cSkippedNames) = await SyncToDirectoryAsync(roles, codexDir, projectOverrideDir: codexDir);
             Console.WriteLine($"Synced {cCount} roles to {codexDir} (codex)");
-            if (cSkipped > 0) Console.WriteLine($"Skipped {cSkipped} (existing override)");
+            if (cSkipped > 0)
+            {
+                Console.WriteLine($"Skipped {cSkipped} roles (project-level override takes precedence):");
+                Console.WriteLine($"  {string.Join(", ", cSkippedNames)}");
+            }
         }
 
         Console.WriteLine();
         Console.WriteLine("Check for new roles periodically:");
         Console.WriteLine("  multiagent-setup sync-roles --pull");
+        Console.WriteLine("  multiagent-setup sync-roles --pull --global  # also update ~/.claude/commands/");
         return 0;
     }
 
-    private static async Task<(int count, int skipped)> SyncToDirectoryAsync(
+    private static async Task<(int count, int skipped, List<string> skippedNames)> SyncToDirectoryAsync(
         List<(string CmdName, string Output)> roles,
         string targetDir,
         string? projectOverrideDir)
@@ -148,6 +186,7 @@ $ARGUMENTS
         }
 
         int count = 0, skipped = 0;
+        var skippedNames = new List<string>();
 
         foreach (var (cmdName, output) in roles)
         {
@@ -155,7 +194,7 @@ $ARGUMENTS
             if (projectOverrideDir is not null && projectOverrideDir != targetDir)
             {
                 var projectCmd = Path.Combine(projectOverrideDir, $"{cmdName}.md");
-                if (File.Exists(projectCmd)) { skipped++; continue; }
+                if (File.Exists(projectCmd)) { skipped++; skippedNames.Add(cmdName); continue; }
             }
 
             await File.WriteAllTextAsync(
@@ -165,7 +204,7 @@ $ARGUMENTS
             count++;
         }
 
-        return (count, skipped);
+        return (count, skipped, skippedNames);
     }
 
     private static string ExtractAfterFrontmatter(string content)

--- a/tools/setup-cli/SyncRolesCommand.cs
+++ b/tools/setup-cli/SyncRolesCommand.cs
@@ -170,11 +170,74 @@ $ARGUMENTS
             }
         }
 
+        // Gemini — global extension (~/.gemini/extensions/agency-agents/) when .gemini/ detected or --global
+        var hasGeminiWorkspace = Directory.Exists(Path.Combine(cwd, ".gemini"));
+        if (hasGeminiWorkspace || globalSync)
+        {
+            var geminiHome = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+            var geminiExtDir = Path.Combine(geminiHome, ".gemini", "extensions", "agency-agents");
+            var gCount = await SyncToGeminiExtensionAsync(roles, geminiExtDir);
+            Console.WriteLine($"Synced {gCount} roles to {geminiExtDir} (gemini extension)");
+        }
+
         Console.WriteLine();
         Console.WriteLine("Check for new roles periodically:");
         Console.WriteLine("  multiagent-setup sync-roles --pull");
         Console.WriteLine("  multiagent-setup sync-roles --pull --global  # also update ~/.claude/commands/");
         return 0;
+    }
+
+    /// <summary>
+    /// Syncs roles to ~/.gemini/extensions/agency-agents/ as TOML slash commands.
+    /// Gemini CLI uses .toml files in extensions/name/commands/ for custom slash commands.
+    /// </summary>
+    private static async Task<int> SyncToGeminiExtensionAsync(
+        List<(string CmdName, string Output)> roles,
+        string extensionDir)
+    {
+        var commandsDir = Path.Combine(extensionDir, "commands");
+        Directory.CreateDirectory(commandsDir);
+
+        // Write extension manifest
+        var manifest = """
+            {
+              "name": "agency-agents",
+              "version": "1.0.0"
+            }
+            """;
+        await File.WriteAllTextAsync(
+            Path.Combine(extensionDir, "gemini-extension.json"),
+            manifest,
+            new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+
+        // Remove previously auto-generated TOML files
+        foreach (var f in Directory.GetFiles(commandsDir, "*.toml"))
+        {
+            var firstLine = File.ReadLines(f).FirstOrDefault() ?? "";
+            if (firstLine.Contains("auto-generated from agency-agents")) File.Delete(f);
+        }
+
+        int count = 0;
+        foreach (var (cmdName, output) in roles)
+        {
+            // TOML multi-line literal strings ('''...''') require no escaping except '''.
+            // Role content from agency-agents doesn't contain ''', so this is safe.
+            var toml = $"""
+                # auto-generated from agency-agents
+                description = "Expert role: {cmdName}"
+                prompt = '''
+                {output}
+                '''
+                """;
+
+            await File.WriteAllTextAsync(
+                Path.Combine(commandsDir, $"{cmdName}.toml"),
+                toml,
+                new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+            count++;
+        }
+
+        return count;
     }
 
     private static async Task<(int count, int skipped, List<string> skippedNames)> SyncToDirectoryAsync(

--- a/tools/setup-cli/Templates/CHANGELOG.md
+++ b/tools/setup-cli/Templates/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+All notable changes to {{PROJECT_NAME}} are documented here.
+Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- Initial project scaffolding

--- a/tools/setup-cli/Templates/docs/process.md
+++ b/tools/setup-cli/Templates/docs/process.md
@@ -1,5 +1,8 @@
 # Operational Process
 
+> **MCPs are optional.** If you haven't run `install-mcps`, skip all graph/Cypher sections below.
+> Use GitHub Issues as your backlog. The pipeline works without AGE or O'Brien.
+
 > **Process v1**. Source of truth: AGE graph `{{GRAPH_NAME}}` + workflow specs.
 
 ## Source of truth
@@ -11,12 +14,14 @@
 | Security findings, Code insights | AGE graph `{{GRAPH_NAME}}` (SecurityFinding, CodeInsight nodes) |
 | Role capabilities (extended) | `docs/role-capabilities.md` |
 | Workflow specs | `docs/workflows/REGISTRY.md` → individual WORKFLOW-*.md |
-| Issues, dependencies | GitHub Project + graph (issue→DEPENDS_ON) |
-| Coordination | O'Brien (active-work, bugs, suggestions) |
+| Issues, dependencies | GitHub Project + graph (issue→DEPENDS_ON) <!-- requires AGE MCP --> |
+| Coordination | O'Brien (active-work, bugs, suggestions) <!-- requires AGE MCP --> |
 
 **Pipeline**: PLAN → BUILD → TEST → VERIFY → SHIP (5 steps, 5 pipelines: feature, bugfix, infra, content, spike).
 
 ## How agents use the graph
+
+<!-- requires AGE MCP -->
 
 Graph `{{GRAPH_NAME}}` is both process definition and **project knowledge base**. Each pipeline step is enriched with graph context:
 

--- a/tools/setup-cli/Templates/providers/codex/.github/workflows/orchestrator-codex.yml
+++ b/tools/setup-cli/Templates/providers/codex/.github/workflows/orchestrator-codex.yml
@@ -1,0 +1,95 @@
+# Autonomous Orchestrator (Codex) — runs the multi-agent pipeline in CI
+#
+# Triggers:
+#   • workflow_dispatch — manual run with a task description
+#   • schedule          — nightly autonomous backlog processing (optional)
+#   • issues labeled    — run when an issue gets the 'orchestrator' label
+#
+# Required secrets:
+#   OPENAI_API_KEY — OpenAI API key (Settings → Secrets → Actions)
+#
+# Usage:
+#   1. Enable this workflow by committing to your workspace repo
+#   2. Go to Actions → Autonomous Orchestrator (Codex) → Run workflow
+#   3. Enter your task (or leave blank for autonomous backlog mode)
+
+name: Autonomous Orchestrator (Codex)
+
+on:
+  workflow_dispatch:
+    inputs:
+      task:
+        description: "Task for the orchestrator (leave blank for autonomous backlog mode)"
+        required: false
+        default: ""
+  issues:
+    types: [labeled]
+  # Uncomment to enable nightly autonomous runs:
+  # schedule:
+  #   - cron: '0 8 * * 1-5'   # 8:00 UTC, Mon–Fri
+
+jobs:
+  orchestrate:
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'schedule' ||
+      (github.event_name == 'issues' && github.event.label.name == 'orchestrator')
+
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout workspace
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Install Codex CLI
+        run: npm install -g @openai/codex
+
+      - name: Set up git identity
+        run: |
+          git config --global user.name "orchestrator[bot]"
+          git config --global user.email "orchestrator@users.noreply.github.com"
+
+      - name: Build task prompt
+        id: task
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+          INPUT_TASK: ${{ inputs.task }}
+        run: |
+          if [ "$EVENT_NAME" = "issues" ]; then
+            {
+              echo 'prompt<<EOF'
+              printf '/orchestrator #%s: %s' "$ISSUE_NUMBER" "$ISSUE_TITLE"
+              echo
+              echo 'EOF'
+            } >> "$GITHUB_OUTPUT"
+          elif [ -n "$INPUT_TASK" ]; then
+            {
+              echo 'prompt<<EOF'
+              printf '/orchestrator %s' "$INPUT_TASK"
+              echo
+              echo 'EOF'
+            } >> "$GITHUB_OUTPUT"
+          else
+            echo "prompt=/orchestrator Pick the top task from the GitHub backlog and execute it." >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run orchestrator
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ORCHESTRATOR_PROMPT: ${{ steps.task.outputs.prompt }}
+        run: |
+          codex --approval-mode full-auto "$ORCHESTRATOR_PROMPT"

--- a/tools/setup-cli/Templates/providers/gemini/.github/workflows/orchestrator-gemini.yml
+++ b/tools/setup-cli/Templates/providers/gemini/.github/workflows/orchestrator-gemini.yml
@@ -1,0 +1,95 @@
+# Autonomous Orchestrator (Gemini CLI) — runs the multi-agent pipeline in CI
+#
+# Triggers:
+#   • workflow_dispatch — manual run with a task description
+#   • schedule          — nightly autonomous backlog processing (optional)
+#   • issues labeled    — run when an issue gets the 'orchestrator' label
+#
+# Required secrets:
+#   GEMINI_API_KEY — Gemini API key (Settings → Secrets → Actions)
+#
+# Usage:
+#   1. Enable this workflow by committing to your workspace repo
+#   2. Go to Actions → Autonomous Orchestrator (Gemini) → Run workflow
+#   3. Enter your task (or leave blank for autonomous backlog mode)
+
+name: Autonomous Orchestrator (Gemini)
+
+on:
+  workflow_dispatch:
+    inputs:
+      task:
+        description: "Task for the orchestrator (leave blank for autonomous backlog mode)"
+        required: false
+        default: ""
+  issues:
+    types: [labeled]
+  # Uncomment to enable nightly autonomous runs:
+  # schedule:
+  #   - cron: '0 8 * * 1-5'   # 8:00 UTC, Mon–Fri
+
+jobs:
+  orchestrate:
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'schedule' ||
+      (github.event_name == 'issues' && github.event.label.name == 'orchestrator')
+
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout workspace
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Install Gemini CLI
+        run: npm install -g @google/gemini-cli
+
+      - name: Set up git identity
+        run: |
+          git config --global user.name "orchestrator[bot]"
+          git config --global user.email "orchestrator@users.noreply.github.com"
+
+      - name: Build task prompt
+        id: task
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+          INPUT_TASK: ${{ inputs.task }}
+        run: |
+          if [ "$EVENT_NAME" = "issues" ]; then
+            {
+              echo 'prompt<<EOF'
+              printf '/orchestrator #%s: %s' "$ISSUE_NUMBER" "$ISSUE_TITLE"
+              echo
+              echo 'EOF'
+            } >> "$GITHUB_OUTPUT"
+          elif [ -n "$INPUT_TASK" ]; then
+            {
+              echo 'prompt<<EOF'
+              printf '/orchestrator %s' "$INPUT_TASK"
+              echo
+              echo 'EOF'
+            } >> "$GITHUB_OUTPUT"
+          else
+            echo "prompt=/orchestrator Pick the top task from the GitHub backlog and execute it." >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run orchestrator
+        env:
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ORCHESTRATOR_PROMPT: ${{ steps.task.outputs.prompt }}
+        run: |
+          gemini --yolo -p "$ORCHESTRATOR_PROMPT"

--- a/tools/setup-cli/Templates/providers/kiro/.kiro/steering/workspace.md
+++ b/tools/setup-cli/Templates/providers/kiro/.kiro/steering/workspace.md
@@ -1,0 +1,64 @@
+---
+inclusion: always
+---
+
+# {{PROJECT_NAME}} — Business Workspace
+
+{{PROJECT_DESCRIPTION}}
+
+**Founder:** {{FOUNDER}}. **Team:** AI agents. **Phase:** {{PHASE}}.
+
+---
+
+## How to start
+
+Determine your mode each session:
+
+| If asked to... | Mode | What to do |
+|----------------|------|------------|
+| "Act as orchestrator / run \<task\>" | **Orchestrator** | Read `docs/process.md`, execute pipeline |
+| "You are the \[role\]" | **Single Expert** | Answer as that role, no pipeline |
+| General question | **Advisor** | Help, suggest next step |
+
+## Context to load
+
+**Always read:** This file (already loaded).
+
+**If task involves code:** `code/{{PROJECT_NAME}}/CLAUDE.md` — architecture, build, tests.
+
+**If orchestrator:** `docs/process.md` — operational manual (pipelines, gates, escalation).
+
+## Workspace structure
+
+```
+~/{{PROJECT_NAME}}/
+├── code/
+│   └── {{PROJECT_NAME}}/   ← main code repo
+├── docs/
+│   ├── process.md           ← pipeline source of truth
+│   ├── role-capabilities.md ← capability index for role selection
+│   └── workflows/           ← workflow specs
+├── .kiro/
+│   └── steering/            ← Kiro steering documents (always loaded)
+```
+
+## Pipeline (summary)
+
+```
+PLAN → BUILD → TEST → VERIFY → SHIP
+```
+
+5 pipeline types: feature, bugfix (skip PLAN), infra, content, spike (PLAN only).
+
+Each step has a gate: `APPROVED` / `NEEDS WORK (reason)`. Retry: 3× → helper → 2× → CEO escalation.
+
+## Rules
+
+- **Confirm intent**: on ambiguous requests — clarify before acting.
+- **Code**: all code changes in `code/{{PROJECT_NAME}}/`, read its CLAUDE.md.
+- **Don't overengineer**: simple solution > complex. Working first, pretty later.
+- **Git discipline**: `git status` before commit, never `git init` in existing repo.
+
+## Backlog
+
+GitHub Project in org `{{GITHUB_ORG}}`. Issues in `{{GITHUB_ORG}}/{{GITHUB_REPO}}`.

--- a/tools/setup-cli/Templates/tools/completions.ps1
+++ b/tools/setup-cli/Templates/tools/completions.ps1
@@ -1,6 +1,8 @@
 # PowerShell completions for multiagent-setup
 # Add to your PowerShell profile ($PROFILE):
 #   . "path\to\tools\completions.ps1"
+# Or use the CLI directly:
+#   multiagent-setup completions pwsh >> $PROFILE
 
 Register-ArgumentCompleter -Native -CommandName multiagent-setup -ScriptBlock {
     param($wordToComplete, $commandAst, $cursorPosition)
@@ -11,13 +13,17 @@ Register-ArgumentCompleter -Native -CommandName multiagent-setup -ScriptBlock {
     # Complete subcommand
     if ($tokens.Count -eq 0 -or ($tokens.Count -eq 1 -and -not $sub.StartsWith('-') -and $wordToComplete)) {
         @(
-            [pscustomobject]@{ name = 'new';          desc = 'Create a new multi-agent workspace' }
-            [pscustomobject]@{ name = 'add-provider'; desc = 'Add a provider to an existing workspace' }
-            [pscustomobject]@{ name = 'update';       desc = 'Update workspace templates to latest version' }
-            [pscustomobject]@{ name = 'sync-roles';   desc = 'Sync agent roles to .claude/commands/ (project-local)' }
-            [pscustomobject]@{ name = 'install-mcps'; desc = 'Install age-mcp and o-brien MCP servers' }
-            [pscustomobject]@{ name = 'hook';         desc = 'Run a built-in hook (cross-platform)' }
-            [pscustomobject]@{ name = 'doctor';       desc = 'Check workspace health — tools, files, hooks, roles' }
+            [pscustomobject]@{ name = 'new';             desc = 'Create a new multi-agent workspace' }
+            [pscustomobject]@{ name = 'init';            desc = 'Add workspace files to an existing git repo' }
+            [pscustomobject]@{ name = 'add-provider';    desc = 'Add a provider to an existing workspace' }
+            [pscustomobject]@{ name = 'remove-provider'; desc = 'Remove a provider from an existing workspace' }
+            [pscustomobject]@{ name = 'list-providers';  desc = 'List providers configured in current workspace' }
+            [pscustomobject]@{ name = 'update';          desc = 'Update workspace templates to latest version' }
+            [pscustomobject]@{ name = 'sync-roles';      desc = 'Sync agent roles to .claude/commands/ (project-local)' }
+            [pscustomobject]@{ name = 'install-mcps';    desc = 'Install age-mcp and o-brien MCP servers' }
+            [pscustomobject]@{ name = 'hook';            desc = 'Run a built-in hook (cross-platform)' }
+            [pscustomobject]@{ name = 'doctor';          desc = 'Check workspace health — tools, files, hooks, roles' }
+            [pscustomobject]@{ name = 'completions';     desc = 'Print shell completion script' }
         ) | Where-Object { $_.name -like "$wordToComplete*" } | ForEach-Object {
             [System.Management.Automation.CompletionResult]::new($_.name, $_.name, 'ParameterValue', $_.desc)
         }
@@ -27,7 +33,15 @@ Register-ArgumentCompleter -Native -CommandName multiagent-setup -ScriptBlock {
     # Complete --provider values when previous token is --provider
     $prevToken = if ($tokens.Count -ge 2) { $tokens[-2].ToString() } else { "" }
     if ($prevToken -eq '--provider') {
-        @('claude', 'nessy', 'gemini', 'codex', 'qwen', 'cursor', 'windsurf', 'copilot', 'cline', 'aider', 'continue', 'roo', 'all') |
+        @('claude', 'nessy', 'gemini', 'codex', 'qwen', 'cursor', 'windsurf', 'copilot', 'cline', 'aider', 'continue', 'roo', 'kiro', 'all') |
+        Where-Object { $_ -like "$wordToComplete*" } | ForEach-Object {
+            [System.Management.Automation.CompletionResult]::new($_, $_, 'ParameterValue', $_)
+        }
+        return
+    }
+
+    if ($prevToken -eq '--template') {
+        @('default', 'saas', 'oss', 'internal') |
         Where-Object { $_ -like "$wordToComplete*" } | ForEach-Object {
             [System.Management.Automation.CompletionResult]::new($_, $_, 'ParameterValue', $_)
         }
@@ -37,13 +51,18 @@ Register-ArgumentCompleter -Native -CommandName multiagent-setup -ScriptBlock {
     # Complete flags per subcommand
     switch ($sub) {
         'new' {
-            @('--provider') | Where-Object { $_ -like "$wordToComplete*" } | ForEach-Object {
+            @('--provider', '--template') | Where-Object { $_ -like "$wordToComplete*" } | ForEach-Object {
+                [System.Management.Automation.CompletionResult]::new($_, $_, 'ParameterName', $_)
+            }
+        }
+        'init' {
+            @('--provider', '--template', '--force') | Where-Object { $_ -like "$wordToComplete*" } | ForEach-Object {
                 [System.Management.Automation.CompletionResult]::new($_, $_, 'ParameterName', $_)
             }
         }
         'add-provider' {
             if ($tokens.Count -eq 1 -or ($tokens.Count -eq 2 -and $wordToComplete)) {
-                @('claude', 'nessy', 'gemini', 'codex', 'qwen', 'cursor', 'windsurf', 'copilot', 'cline', 'aider', 'continue', 'roo', 'all') | Where-Object { $_ -like "$wordToComplete*" } | ForEach-Object {
+                @('claude', 'nessy', 'gemini', 'codex', 'qwen', 'cursor', 'windsurf', 'copilot', 'cline', 'aider', 'continue', 'roo', 'kiro', 'all') | Where-Object { $_ -like "$wordToComplete*" } | ForEach-Object {
                     [System.Management.Automation.CompletionResult]::new($_, $_, 'ParameterValue', $_)
                 }
             } else {
@@ -52,13 +71,24 @@ Register-ArgumentCompleter -Native -CommandName multiagent-setup -ScriptBlock {
                 }
             }
         }
+        'remove-provider' {
+            if ($tokens.Count -eq 1 -or ($tokens.Count -eq 2 -and $wordToComplete)) {
+                @('nessy', 'gemini', 'codex', 'qwen', 'cursor', 'windsurf', 'copilot', 'cline', 'aider', 'continue', 'roo', 'kiro') | Where-Object { $_ -like "$wordToComplete*" } | ForEach-Object {
+                    [System.Management.Automation.CompletionResult]::new($_, $_, 'ParameterValue', $_)
+                }
+            } else {
+                @('--force', '--dry-run') | Where-Object { $_ -like "$wordToComplete*" } | ForEach-Object {
+                    [System.Management.Automation.CompletionResult]::new($_, $_, 'ParameterName', $_)
+                }
+            }
+        }
         'update' {
-            @('--force') | Where-Object { $_ -like "$wordToComplete*" } | ForEach-Object {
+            @('--force', '--dry-run') | Where-Object { $_ -like "$wordToComplete*" } | ForEach-Object {
                 [System.Management.Automation.CompletionResult]::new($_, $_, 'ParameterName', $_)
             }
         }
         'sync-roles' {
-            @('--clone', '--pull', '--agency-dir') | Where-Object { $_ -like "$wordToComplete*" } | ForEach-Object {
+            @('--clone', '--pull', '--global', '--agency-dir') | Where-Object { $_ -like "$wordToComplete*" } | ForEach-Object {
                 [System.Management.Automation.CompletionResult]::new($_, $_, 'ParameterName', $_)
             }
         }
@@ -70,6 +100,16 @@ Register-ArgumentCompleter -Native -CommandName multiagent-setup -ScriptBlock {
         'hook' {
             @('block-dangerous', 'enforce-commit-msg', 'auto-lint', 'log-agent', 'stop-guard', 'research-reminder') |
             Where-Object { $_ -like "$wordToComplete*" } | ForEach-Object {
+                [System.Management.Automation.CompletionResult]::new($_, $_, 'ParameterValue', $_)
+            }
+        }
+        'doctor' {
+            @('--for') | Where-Object { $_ -like "$wordToComplete*" } | ForEach-Object {
+                [System.Management.Automation.CompletionResult]::new($_, $_, 'ParameterName', $_)
+            }
+        }
+        'completions' {
+            @('zsh', 'pwsh') | Where-Object { $_ -like "$wordToComplete*" } | ForEach-Object {
                 [System.Management.Automation.CompletionResult]::new($_, $_, 'ParameterValue', $_)
             }
         }

--- a/tools/setup-cli/Templates/tools/completions.zsh
+++ b/tools/setup-cli/Templates/tools/completions.zsh
@@ -29,15 +29,19 @@ unset _agent_cmd
 
 # --- multiagent-setup CLI ---
 _multiagent_setup() {
-  local -a subcommands providers hooks
+  local -a subcommands providers templates shells hooks
   subcommands=(
     'new:Create a new multi-agent workspace'
+    'init:Add workspace files to an existing git repo'
     'add-provider:Add a provider to an existing workspace'
+    'remove-provider:Remove a provider from an existing workspace'
+    'list-providers:List providers configured in current workspace'
     'update:Update workspace templates to latest version'
     'sync-roles:Sync agent roles to ~/.claude/commands/'
     'install-mcps:Install age-mcp and o-brien MCP servers'
     'hook:Run a built-in hook (cross-platform)'
     'doctor:Check workspace health — tools, files, hooks, roles'
+    'completions:Print shell completion script'
   )
   providers=(
     'claude:Claude Code by Anthropic (default)'
@@ -52,7 +56,18 @@ _multiagent_setup() {
     'aider:Aider AI pair programmer'
     'continue:Continue.dev VS Code/JetBrains extension'
     'roo:Roo Code VS Code extension'
+    'kiro:Amazon Kiro VS Code extension'
     'all:All providers at once'
+  )
+  templates=(
+    'default:Generic workspace'
+    'saas:SaaS product (user-impact gates, SLO review)'
+    'oss:Open source (CHANGELOG, semver gates)'
+    'internal:Internal tools (lighter pipeline)'
+  )
+  shells=(
+    'zsh:zsh completion script'
+    'pwsh:PowerShell completion script'
   )
   hooks=(
     'block-dangerous' 'enforce-commit-msg' 'auto-lint'
@@ -62,25 +77,35 @@ _multiagent_setup() {
   case $CURRENT in
     2) _describe 'subcommand' subcommands ;;
     *) case ${words[2]} in
-      new)
+      new|init)
         case ${words[CURRENT-1]} in
           --provider) _describe 'provider' providers ;;
-          *) _arguments '--provider[Provider to scaffold]:provider:->p' && _describe 'provider' providers ;;
+          --template) _describe 'template' templates ;;
+          *) compadd -- --provider --template ;;
         esac ;;
       add-provider)
         case $CURRENT in
           3) _describe 'provider' providers ;;
           *) compadd -- --force ;;
         esac ;;
+      remove-provider)
+        case $CURRENT in
+          3) _describe 'provider' providers ;;
+          *) compadd -- --force --dry-run ;;
+        esac ;;
+      list-providers) ;; # no args
       update)
-        compadd -- --force ;;
+        compadd -- --force --dry-run ;;
       sync-roles)
-        compadd -- --clone --pull --agency-dir ;;
+        compadd -- --clone --pull --global --agency-dir ;;
       install-mcps)
         compadd -- --docker --manual --age-conn --obrien-conn --target ;;
       hook)
         _describe 'hook' hooks ;;
-      doctor) ;; # no args
+      doctor)
+        compadd -- --for ;;
+      completions)
+        _describe 'shell' shells ;;
     esac ;;
   esac
 }

--- a/tools/setup-cli/Templates/variants/internal/docs/process.md
+++ b/tools/setup-cli/Templates/variants/internal/docs/process.md
@@ -1,0 +1,150 @@
+# Operational Process
+
+> **Template**: Internal Tools. Used by your team only — optimize for speed over ceremony. Lightweight pipeline with relaxed gates.
+
+> **MCPs are optional.** If you haven't run `install-mcps`, skip all graph/Cypher sections below.
+> Use GitHub Issues as your backlog. The pipeline works without AGE or O'Brien.
+
+> **Process v1**. Source of truth: AGE graph `{{GRAPH_NAME}}` + workflow specs.
+
+## Source of truth
+
+| What | Where |
+|------|-------|
+| Pipelines, Steps, Roles | AGE graph `{{GRAPH_NAME}}` |
+| Role capabilities | `docs/role-capabilities.md` |
+| Workflow specs | `docs/workflows/REGISTRY.md` |
+| Issues | GitHub Project `{{GITHUB_ORG}}/{{GITHUB_REPO}}` |
+
+**Pipeline**: PLAN → BUILD → TEST → VERIFY → SHIP. Internal tools may skip PLAN and VERIFY for small changes (see rules below).
+
+---
+
+## Three entry points
+
+| Mode | Launch | Description |
+|------|--------|-------------|
+| CEO Mode | `/orchestrator <task>` | CEO gives a specific task |
+| Single Expert | `/<role> <question>` | Direct role call, no pipeline |
+| Autonomous | `claude -p "/orchestrator ..." --max-turns 50` | Headless, from backlog |
+
+---
+
+## Models by role
+
+| Tier | Model | Roles |
+|------|-------|-------|
+| Strategic | opus | PM, Architects, Security, Orchestrator |
+| Execution | sonnet | Coder, Frontend, DevOps, Tech Writer |
+| Validation | opus | Code Reviewer, Reality Checker |
+| Routine | haiku | Data gathering, formatting, lookups |
+
+---
+
+## CEO control points
+
+CEO **does not participate** in day-to-day operations. Escalate only for:
+
+| Situation | How to notify |
+|-----------|---------------|
+| New infrastructure cost >$100/month | `needs-ceo` Issue |
+| Data deletion affecting >1000 records | `needs-ceo` Issue |
+| External integrations or API keys | `needs-ceo` Issue |
+| 5+ failures on a single step | `needs-ceo` Issue with dossier |
+
+No escalation needed for: design decisions, architecture choices, feature scope, minor performance changes.
+
+---
+
+## Dynamic role selection
+
+Orchestrator selects roles dynamically via `docs/role-capabilities.md`:
+
+1. **Signals**: labels, files, keywords, task domain
+2. **Match**: signals → capability index → Primary + Secondary roles
+3. **Fallback**: if no role fits → create ad-hoc role
+
+---
+
+## Helper mechanism on blockers
+
+3 retry → helper → 2 retry → CEO escalation (for escalation criteria above only).
+
+---
+
+## Simplified pipeline for internal tools
+
+| Pipeline type | Required steps | Steps you may skip |
+|---------------|---------------|-------------------|
+| `feature` | BUILD → TEST → SHIP | PLAN (for <1 day tasks), VERIFY (for low-risk changes) |
+| `bugfix` | BUILD → SHIP | TEST (for trivial fixes), VERIFY |
+| `infra` | BUILD → SHIP | PLAN, VERIFY |
+| `content` | BUILD → SHIP | PLAN, VERIFY |
+| `spike` | PLAN | — |
+
+**When to keep VERIFY**: changes to shared infrastructure, auth/permissions, data pipelines, or anything used by >5 people regularly.
+
+---
+
+## Operational rules
+
+### Worktree isolation
+
+All agents modifying code **must** work in a git worktree:
+
+```bash
+git worktree add ../<project>-wt-<issue> -b <branch-name> main
+```
+
+### RED CI — fix before new PR
+
+CI RED on PR → fix **in the same PR**. Max 3 attempts, then helper.
+
+---
+
+## Task-level locking
+
+Optimistic lock via O'Brien to prevent two orchestrators from taking the same task:
+
+```
+1. o-brien.search(tags: ["active-work", "issue-NNN"]) → if found → SKIP
+2. o-brien.store(content: "LOCK: issue #NNN", tags: ["active-work", "issue-NNN", "lock"])
+3. Wait 2 sec → re-check → if >1 records → delete own lock, SKIP
+4. Otherwise → task locked, continue
+```
+
+---
+
+## Autonomous run
+
+```bash
+claude -p "/orchestrator Take next P0+P1 tasks from backlog. \
+  Execute autonomously." \
+  --allowedTools "Bash,Read,Edit,Write,Agent,Glob,Grep,Skill" \
+  --max-turns 100
+```
+
+Morning check:
+```bash
+gh issue list --label needs-ceo --repo {{GITHUB_ORG}}/{{GITHUB_REPO}}
+```
+
+---
+
+## Internal tools rules
+
+### Pragmatic quality bar
+
+Code quality standard: working and maintainable > perfect. Internal tools that work reliably beat beautifully designed tools that take 3x longer to build.
+
+- Skip formal design docs for tasks under 1 day
+- README is sufficient documentation for most internal tools
+- Tests are important for anything that runs on a schedule or handles data
+
+### Access and secrets
+
+All secrets must go in environment variables or a secrets manager (never hardcoded). Internal does not mean insecure — log access, track who uses what.
+
+### Deployment
+
+Prefer simple deployment: single binary, Docker Compose, or a cron job over complex orchestration. The person on-call should be able to deploy a fix in under 10 minutes.

--- a/tools/setup-cli/Templates/variants/oss/docs/process.md
+++ b/tools/setup-cli/Templates/variants/oss/docs/process.md
@@ -1,0 +1,167 @@
+# Operational Process
+
+> **Template**: Open Source (OSS). Public codebase — every commit is potentially reviewed by the community. Optimize for clarity, contributor experience, and backward compatibility.
+
+> **MCPs are optional.** If you haven't run `install-mcps`, skip all graph/Cypher sections below.
+> Use GitHub Issues as your backlog. The pipeline works without AGE or O'Brien.
+
+> **Process v1**. Source of truth: AGE graph `{{GRAPH_NAME}}` + workflow specs.
+
+## Source of truth
+
+| What | Where |
+|------|-------|
+| Pipelines, Steps, Roles | AGE graph `{{GRAPH_NAME}}` (Pipeline→HAS_STEP→Step→PERFORMED_BY→Role) |
+| Modules, code dependencies | AGE graph `{{GRAPH_NAME}}` (Module→DEPENDS_ON→Module, Module→BELONGS_TO→Repo) |
+| Security findings, Code insights | AGE graph `{{GRAPH_NAME}}` (SecurityFinding, CodeInsight nodes) |
+| Role capabilities (extended) | `docs/role-capabilities.md` |
+| Workflow specs | `docs/workflows/REGISTRY.md` → individual WORKFLOW-*.md |
+| Issues, dependencies | GitHub Project + graph (issue→DEPENDS_ON) <!-- requires AGE MCP --> |
+| Coordination | O'Brien (active-work, bugs, suggestions) <!-- requires AGE MCP --> |
+
+**Pipeline**: PLAN → BUILD → TEST → VERIFY → SHIP (5 steps, 5 pipelines: feature, bugfix, infra, content, spike).
+
+---
+
+## Three entry points
+
+| Mode | Launch | Description |
+|------|--------|-------------|
+| CEO Mode | `/orchestrator <task>` | CEO gives a specific task |
+| Single Expert | `/<role> <question>` | Direct role call, no pipeline |
+| Autonomous | `claude -p "/orchestrator ..." --max-turns 50` | Headless, from backlog |
+
+---
+
+## Models by role
+
+| Tier | Model | Roles |
+|------|-------|-------|
+| Strategic | opus | PM, Architects, Security, Orchestrator |
+| Execution | sonnet | Coder, Frontend, DevOps, Tech Writer, Marketing, Designer |
+| Validation | opus | Code Reviewer, Reality Checker |
+| Routine | haiku | Data gathering, formatting, lookups |
+
+---
+
+## CEO control points
+
+CEO **does not participate** in operations. Needed only when:
+
+| Situation | How to notify |
+|-----------|---------------|
+| Ambiguous classification | `needs-ceo` Issue |
+| Public content | PR with `needs-ceo-review` |
+| Breaking API change | `needs-ceo` Issue |
+| Infra decisions with costs | `needs-ceo` Issue |
+| 5+ failures (3 role + 2 helper) | `needs-ceo` Issue with dossier |
+
+---
+
+## Dynamic role selection
+
+Orchestrator selects roles dynamically via `docs/role-capabilities.md` + graph:
+
+1. **Signals**: labels, files, keywords, task domain
+2. **Match**: signals → capability index + graph → Primary + Secondary roles
+3. **Composition**: sequential (A → B), parallel (A + B), or composite prompt
+4. **Fallback**: if no role fits → create ad-hoc role
+
+---
+
+## Helper mechanism on blockers
+
+3 retry → helper → 2 retry with recommendation → CEO escalation.
+
+Helper MUST NOT be the same role that failed.
+
+**CEO escalation**: create GitHub Issue with `needs-ceo` label. Orchestrator does not block — moves to next task.
+
+---
+
+## Operational rules
+
+### Worktree isolation — required for code
+
+All agents modifying code **must** work in a git worktree:
+
+```bash
+git worktree add ../<project>-wt-<issue> -b <branch-name> main
+```
+
+Each bugfix/feature creates its own worktree. After merge — `git worktree remove`.
+
+### RED CI — fix before new PR
+
+CI RED on PR → fix **in the same PR**. Max 3 attempts, then helper.
+
+---
+
+## Task-level locking
+
+Optimistic lock via O'Brien to prevent two orchestrators from taking the same task:
+
+```
+1. o-brien.search(tags: ["active-work", "issue-NNN"]) → if found → SKIP
+2. o-brien.store(content: "LOCK: issue #NNN", tags: ["active-work", "issue-NNN", "lock"])
+3. Wait 2 sec → re-check → if >1 records → race → delete own lock, SKIP
+4. Otherwise → task locked, continue
+```
+
+---
+
+## Autonomous run
+
+```bash
+claude -p "/orchestrator Take next P0+P1 tasks from backlog. \
+  Load process from graph {{GRAPH_NAME}}. Execute autonomously." \
+  --allowedTools "Bash,Read,Edit,Write,Agent,Glob,Grep,Skill" \
+  --max-turns 100
+```
+
+Morning CEO check:
+```bash
+gh issue list --label needs-ceo --repo {{GITHUB_ORG}}/{{GITHUB_REPO}}
+gh pr list --repo {{GITHUB_ORG}}/{{GITHUB_REPO}}
+```
+
+---
+
+## OSS-specific rules
+
+### CHANGELOG — required in SHIP
+
+Every SHIP step must include an update to `CHANGELOG.md` following [Keep a Changelog](https://keepachangelog.com) format:
+- `Added` — new features
+- `Changed` — changes to existing functionality
+- `Deprecated` — soon-to-be removed features
+- `Removed` — removed features
+- `Fixed` — bug fixes
+- `Security` — vulnerabilities fixed
+
+### Semantic versioning — VERIFY gate
+
+VERIFY must classify the change and confirm version bump intent:
+- Breaking public API change → major version bump required (`needs-ceo`)
+- New public API (backward-compatible) → minor version bump
+- Bug fixes, docs, internal changes → patch version bump
+
+### Backward compatibility — escalation required
+
+Breaking changes require CEO escalation (`needs-ceo`) and must include:
+1. Clear description of what breaks and why
+2. Migration guide in `docs/` or PR description
+3. Deprecation notice in the previous release (if feasible)
+
+### Contributor-friendly output
+
+- PR titles and commit messages must be clear enough for external contributors
+- PR descriptions must explain **why** the change is made, not just what
+- New public APIs must include docstrings or inline documentation
+- `/engineering-technical-writer` must review docs in the VERIFY step for any user-facing change
+
+### Security disclosure
+
+Security issues reported via GitHub Security Advisories must bypass the normal pipeline:
+→ fix in private fork → coordinated disclosure → release → public announcement.
+Assign `/engineering-security-engineer` immediately. Escalate to CEO.

--- a/tools/setup-cli/Templates/variants/saas/docs/process.md
+++ b/tools/setup-cli/Templates/variants/saas/docs/process.md
@@ -1,0 +1,157 @@
+# Operational Process
+
+> **Template**: SaaS (Software-as-a-Service). Customer-facing product — treat every change as potentially affecting live users.
+
+> **MCPs are optional.** If you haven't run `install-mcps`, skip all graph/Cypher sections below.
+> Use GitHub Issues as your backlog. The pipeline works without AGE or O'Brien.
+
+> **Process v1**. Source of truth: AGE graph `{{GRAPH_NAME}}` + workflow specs.
+
+## Source of truth
+
+| What | Where |
+|------|-------|
+| Pipelines, Steps, Roles | AGE graph `{{GRAPH_NAME}}` (Pipeline→HAS_STEP→Step→PERFORMED_BY→Role) |
+| Modules, code dependencies | AGE graph `{{GRAPH_NAME}}` (Module→DEPENDS_ON→Module, Module→BELONGS_TO→Repo) |
+| Security findings, Code insights | AGE graph `{{GRAPH_NAME}}` (SecurityFinding, CodeInsight nodes) |
+| Role capabilities (extended) | `docs/role-capabilities.md` |
+| Workflow specs | `docs/workflows/REGISTRY.md` → individual WORKFLOW-*.md |
+| Issues, dependencies | GitHub Project + graph (issue→DEPENDS_ON) <!-- requires AGE MCP --> |
+| Coordination | O'Brien (active-work, bugs, suggestions) <!-- requires AGE MCP --> |
+
+**Pipeline**: PLAN → BUILD → TEST → VERIFY → SHIP (5 steps, 5 pipelines: feature, bugfix, infra, content, spike).
+
+---
+
+## Three entry points
+
+| Mode | Launch | Description |
+|------|--------|-------------|
+| CEO Mode | `/orchestrator <task>` | CEO gives a specific task |
+| Single Expert | `/<role> <question>` | Direct role call, no pipeline |
+| Autonomous | `claude -p "/orchestrator ..." --max-turns 50` | Headless, from backlog |
+
+---
+
+## Models by role
+
+| Tier | Model | Roles |
+|------|-------|-------|
+| Strategic | opus | PM, Architects, Security, Orchestrator |
+| Execution | sonnet | Coder, Frontend, DevOps, Tech Writer, Marketing, Designer |
+| Validation | opus | Code Reviewer, Reality Checker |
+| Routine | haiku | Data gathering, formatting, lookups |
+
+---
+
+## CEO control points
+
+CEO **does not participate** in operations. Needed only when:
+
+| Situation | How to notify |
+|-----------|---------------|
+| Ambiguous classification | `needs-ceo` Issue |
+| Public content | PR with `needs-ceo-review` |
+| Breaking API change | `needs-ceo` Issue |
+| Infra decisions with costs | `needs-ceo` Issue |
+| 5+ failures (3 role + 2 helper) | `needs-ceo` Issue with dossier |
+
+---
+
+## Dynamic role selection
+
+Orchestrator selects roles dynamically via `docs/role-capabilities.md` + graph:
+
+1. **Signals**: labels, files, keywords, task domain
+2. **Match**: signals → capability index + graph → Primary + Secondary roles
+3. **Composition**: sequential (A → B), parallel (A + B), or composite prompt
+4. **Fallback**: if no role fits → create ad-hoc role
+
+---
+
+## Helper mechanism on blockers
+
+3 retry → helper → 2 retry with recommendation → CEO escalation.
+
+Helper MUST NOT be the same role that failed.
+
+**CEO escalation**: create GitHub Issue with `needs-ceo` label. Orchestrator does not block — moves to next task.
+
+---
+
+## Operational rules
+
+### Worktree isolation — required for code
+
+All agents modifying code **must** work in a git worktree:
+
+```bash
+git worktree add ../<project>-wt-<issue> -b <branch-name> main
+```
+
+Each bugfix/feature creates its own worktree. After merge — `git worktree remove`.
+
+### RED CI — fix before new PR
+
+CI RED on PR → fix **in the same PR**. Max 3 attempts, then helper.
+
+---
+
+## Task-level locking
+
+Optimistic lock via O'Brien to prevent two orchestrators from taking the same task:
+
+```
+1. o-brien.search(tags: ["active-work", "issue-NNN"]) → if found → SKIP
+2. o-brien.store(content: "LOCK: issue #NNN", tags: ["active-work", "issue-NNN", "lock"])
+3. Wait 2 sec → re-check → if >1 records → race → delete own lock, SKIP
+4. Otherwise → task locked, continue
+```
+
+---
+
+## Autonomous run
+
+```bash
+claude -p "/orchestrator Take next P0+P1 tasks from backlog. \
+  Load process from graph {{GRAPH_NAME}}. Execute autonomously." \
+  --allowedTools "Bash,Read,Edit,Write,Agent,Glob,Grep,Skill" \
+  --max-turns 100
+```
+
+Morning CEO check:
+```bash
+gh issue list --label needs-ceo --repo {{GITHUB_ORG}}/{{GITHUB_REPO}}
+gh pr list --repo {{GITHUB_ORG}}/{{GITHUB_REPO}}
+```
+
+---
+
+## SaaS-specific rules
+
+### User impact — required in VERIFY
+
+Every PR touching user-facing code must include in the VERIFY checklist:
+- Does this affect existing user data? (migration needed?)
+- Does this change user-visible behavior? (comms or announcement needed?)
+- Error budget impact — acceptable regression in SLOs?
+
+### Feature flags — preferred for risky changes
+
+Use feature flags for changes that:
+- Touch core user flows (auth, billing, data access)
+- Cannot be rolled back in under 5 minutes
+- Affect >10% of active users
+
+### Analytics events — required for new features
+
+Every new user-facing feature must fire at least one analytics event. Include event spec in the PLAN step output.
+
+### SLO gate — added to VERIFY
+
+Orchestrator: add SLO/error-budget review to the VERIFY step for all feature and infra pipelines.
+Assign to `/engineering-devops-automator` or `/engineering-backend-architect`.
+
+### Deployment strategy
+
+Prefer canary or blue-green deploys for changes to stateful services. Include rollback plan in the SHIP step.

--- a/tools/setup-cli/UpdateCommand.cs
+++ b/tools/setup-cli/UpdateCommand.cs
@@ -111,6 +111,9 @@ public sealed class UpdateCommand(bool force = false)
     {
         var asm = Assembly.GetExecutingAssembly();
         int skippedCount = 0;
+        int skippedDocs  = 0;
+        int skippedHooks = 0;
+        int skippedOther = 0;
 
         foreach (var resourceName in asm.GetManifestResourceNames())
         {
@@ -122,6 +125,12 @@ public sealed class UpdateCommand(bool force = false)
             if (File.Exists(outputPath) && !force)
             {
                 skippedCount++;
+                if (outputRel.StartsWith(".claude/hooks/") || outputRel == ".claude/mcp.json")
+                    skippedHooks++;
+                else if (outputRel.StartsWith("docs/") || outputRel.StartsWith("tools/"))
+                    skippedDocs++;
+                else
+                    skippedOther++;
                 continue;
             }
 
@@ -147,7 +156,12 @@ public sealed class UpdateCommand(bool force = false)
         }
 
         if (skippedCount > 0)
+        {
             Console.WriteLine($"  INFO: Skipped {skippedCount} existing files (use --force to overwrite)");
+            if (skippedDocs > 0)  Console.WriteLine($"         {skippedDocs} docs/tools file(s)");
+            if (skippedHooks > 0) Console.WriteLine($"         {skippedHooks} hook/config file(s)");
+            if (skippedOther > 0) Console.WriteLine($"         {skippedOther} provider template(s)");
+        }
     }
 
     private static string? ResolveOutputPath(string resourceName, string[] providers)

--- a/tools/setup-cli/UpdateCommand.cs
+++ b/tools/setup-cli/UpdateCommand.cs
@@ -11,7 +11,7 @@ namespace MultiagentSetup;
 /// Provider files are re-extracted for every provider detected in the workspace.
 /// Existing files are preserved by default; use --force to overwrite.
 /// </summary>
-public sealed class UpdateCommand(bool force = false)
+public sealed class UpdateCommand(bool force = false, bool dryRun = false)
 {
     // Resources that should be updated but are not provider-specific.
     // CLAUDE.md and context files (GEMINI.md etc.) are intentionally excluded —
@@ -41,14 +41,24 @@ public sealed class UpdateCommand(bool force = false)
         var providers   = DetectProviders(cwd);
         var vars        = BuildVars(cwd, projectName);
 
-        Console.WriteLine($"\nUpdating workspace: {cwd}");
-        Console.WriteLine($"Detected providers: {(providers.Length > 0 ? string.Join(", ", providers) : "claude (default)")}");
-        Console.WriteLine($"Mode: {(force ? "overwrite (--force)" : "skip existing")}");
+        if (dryRun)
+        {
+            Console.WriteLine($"\n[DRY RUN] No changes will be written.");
+            Console.WriteLine($"Workspace: {cwd}");
+            Console.WriteLine($"Detected providers: {(providers.Length > 0 ? string.Join(", ", providers) : "claude (default)")}");
+            Console.WriteLine($"Mode: {(force ? "overwrite (--force)" : "skip existing")}");
+        }
+        else
+        {
+            Console.WriteLine($"\nUpdating workspace: {cwd}");
+            Console.WriteLine($"Detected providers: {(providers.Length > 0 ? string.Join(", ", providers) : "claude (default)")}");
+            Console.WriteLine($"Mode: {(force ? "overwrite (--force)" : "skip existing")}");
+        }
         Console.WriteLine();
 
         ExtractResources(cwd, vars, providers);
 
-        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        if (!dryRun && !RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {
             var scripts = Directory.GetFiles(cwd, "*.sh", SearchOption.AllDirectories)
                 .Concat(Directory.GetFiles(cwd, "*.zsh", SearchOption.AllDirectories));
@@ -57,8 +67,11 @@ public sealed class UpdateCommand(bool force = false)
         }
 
         Console.WriteLine();
-        Console.WriteLine("Workspace updated.");
-        if (!force)
+        if (dryRun)
+            Console.WriteLine("Dry run complete. No files were modified. Remove --dry-run to apply.");
+        else
+            Console.WriteLine("Workspace updated.");
+        if (!force && !dryRun)
             Console.WriteLine("Tip: use --force to overwrite all existing files.");
         Console.WriteLine();
         return 0;
@@ -122,7 +135,8 @@ public sealed class UpdateCommand(bool force = false)
 
             var outputPath = Path.Combine(root, outputRel.Replace('/', Path.DirectorySeparatorChar));
 
-            if (File.Exists(outputPath) && !force)
+            var exists = File.Exists(outputPath);
+            if (exists && !force)
             {
                 skippedCount++;
                 if (outputRel.StartsWith(".claude/hooks/") || outputRel == ".claude/mcp.json")
@@ -131,6 +145,16 @@ public sealed class UpdateCommand(bool force = false)
                     skippedDocs++;
                 else
                     skippedOther++;
+                if (dryRun)
+                    Console.WriteLine($"  SKIP: {outputRel}  [existing — use --force to overwrite]");
+                continue;
+            }
+
+            if (dryRun)
+            {
+                Console.WriteLine(exists
+                    ? $"  WOULD OVERWRITE: {outputRel}"
+                    : $"  WOULD CREATE:    {outputRel}");
                 continue;
             }
 
@@ -155,7 +179,7 @@ public sealed class UpdateCommand(bool force = false)
             }
         }
 
-        if (skippedCount > 0)
+        if (skippedCount > 0 && !dryRun)
         {
             Console.WriteLine($"  INFO: Skipped {skippedCount} existing files (use --force to overwrite)");
             if (skippedDocs > 0)  Console.WriteLine($"         {skippedDocs} docs/tools file(s)");

--- a/tools/setup-cli/UpdateCommand.cs
+++ b/tools/setup-cli/UpdateCommand.cs
@@ -73,6 +73,8 @@ public sealed class UpdateCommand(bool force = false, bool dryRun = false)
             Console.WriteLine("Workspace updated.");
         if (!force && !dryRun)
             Console.WriteLine("Tip: use --force to overwrite all existing files.");
+        if (!dryRun)
+            Console.WriteLine("Tip: agent roles (.claude/commands/) are managed separately — run 'multiagent-setup sync-roles --pull' to update them.");
         Console.WriteLine();
         return 0;
     }

--- a/tools/setup-cli/UpdateCommand.cs
+++ b/tools/setup-cli/UpdateCommand.cs
@@ -110,6 +110,7 @@ public sealed class UpdateCommand(bool force = false)
     private void ExtractResources(string root, Dictionary<string, string> vars, string[] providers)
     {
         var asm = Assembly.GetExecutingAssembly();
+        int skippedCount = 0;
 
         foreach (var resourceName in asm.GetManifestResourceNames())
         {
@@ -120,7 +121,7 @@ public sealed class UpdateCommand(bool force = false)
 
             if (File.Exists(outputPath) && !force)
             {
-                Console.WriteLine($"  SKIP: {outputRel}");
+                skippedCount++;
                 continue;
             }
 
@@ -144,6 +145,9 @@ public sealed class UpdateCommand(bool force = false)
                 Console.WriteLine($"  OK:   {outputRel}");
             }
         }
+
+        if (skippedCount > 0)
+            Console.WriteLine($"  INFO: Skipped {skippedCount} existing files (use --force to overwrite)");
     }
 
     private static string? ResolveOutputPath(string resourceName, string[] providers)


### PR DESCRIPTION
## Summary

Complete multi-pass improvement cycle: UX/DX review, product features, developer advocate improvements, website update, and SEO.

### DX Fixes (#82-#113)
- Reality Checker added to VERIFY phase in both feature and bugfix pipelines
- sync-roles: default to local .claude/commands/; --global flag for ~/.claude/commands/
- init command: correct mode detection, GPG sign bypass, error messages with recovery hints
- bootstrap.sh: version verification after install, PATH persistence on macOS, no silent brew upgrade failure
- README: PLAN step in pipeline description, example of pipeline output, two-CLAUDE.md explanation
- stop-guard: per-session baseline, not shared default
- hook help text: includes research-reminder; --help now shows usage instead of executing
- sync-roles/install-mcps: respect --help/-h flags
- UpdateCommand: skipped files summary with categorization
- sync-roles: clear recovery guidance on clone/pull failure
- HooksCommand: unknown hook error lists valid hook names
- doctor: exit code 1 on errors, workspace file checks
- update: exit code 1 on errors

### New Features (#109-#113)
- add-provider, remove-provider, list-providers commands
- --template flag (saas, oss, internal, default) with variant process.md overlays
- doctor --for preflight mode
- bootstrap.ps1 init mode detection

### Kiro + CI Workflows (#126-#127)
- Kiro (Amazon) provider: .kiro/steering/workspace.md with inclusion: always
- Gemini CI workflow: orchestrator-gemini.yml
- Codex CI workflow: orchestrator-codex.yml
- DoctorCommand: detects .kiro directory

### Product Features (#128-#129)
- completions subcommand: multiagent-setup completions zsh|pwsh prints completion script from binary
- --dry-run for update: preview WOULD CREATE/OVERWRITE/SKIP without writing
- --dry-run for remove-provider: preview deletions without making changes
- Shell completions updated: all 13 providers, all commands, all flags

### Documentation (#130-#131)
- IDE provider quickstart: how to invoke orchestrator in Cursor/Windsurf/Copilot/Cline/Continue/Roo/Kiro
- Autonomous mode setup guide: GitHub Project structure, issue format, CI trigger, loop mode examples

### Website / SEO (gh-pages)
- Add Kiro provider card
- Fix provider count 12→13 throughout (badge, feature card, og:description, JSON-LD, terminal output)
- Sync llms.txt and llms-full.txt (was 8 providers, now complete with all 13 + new commands)
- Improve meta description with key search terms
- Add Kiro to JSON-LD keywords

## Test plan
- [ ] dotnet build passes (0 warnings, 0 errors) ✅
- [ ] multiagent-setup completions zsh prints valid zsh script ✅
- [ ] multiagent-setup update --dry-run shows preview without writing ✅
- [ ] multiagent-setup remove-provider --dry-run shows preview without deleting ✅
- [ ] Website at neftedollar.com/multiagent-template/ shows 13 providers including Kiro ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)